### PR TITLE
Numbers to string - Fixes #21

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,7 +22,7 @@ module.exports = function(grunt) {
 			options: {
 				configFile: "conf/eslint.json"
 			},
-			src: ["index.js"]
+			src: ["index.js", "commands/**/*.js", "src/**/*.js", "test/**/*.js"]
 		}
 	});
 

--- a/commands/get.js
+++ b/commands/get.js
@@ -60,9 +60,7 @@ module.exports = function getCommand (vorpal) {
 				'transaction': isTransactionQuery
 			};
 
-			let bigNumberWorkaround = this.commandWrapper.command.split(" ")[2];
-
-			let output = getType[userInput.type](bigNumberWorkaround);
+			let output = getType[userInput.type](userInput.input);
 
 			if(process.env.NODE_ENV === 'test') {
 

--- a/commands/list.js
+++ b/commands/list.js
@@ -44,20 +44,6 @@ module.exports = function listCommand(vorpal) {
 		}
 	}
 
-	function filterCommandForFlags (commands, input) {
-
-		return input.filter(function (commandInput) {
-			return commands.indexOf(commandInput) === -1
-		});
-
-	}
-
-	function getFlags (commands) {
-		return commands.map(function (command) {
-			return command.flags;
-		});
-	}
-
 	vorpal
 		.command('list <type> [variadic...]')
 		.option('-j, --json', 'Sets output to json')
@@ -65,13 +51,6 @@ module.exports = function listCommand(vorpal) {
 		.description('Get information from <type> with parameters [input, input, ...]')
 		.autocomplete(['accounts', 'addresses', 'blocks', 'delegates', 'transactions'])
 		.action(function(userInput) {
-
-			let bigNumberWorkaround = this.commandWrapper.command.split(" ");
-			bigNumberWorkaround.shift();
-			bigNumberWorkaround.shift();
-
-			let flags = getFlags(this.commandObject.options).toString();
-			let fixedCommands = filterCommandForFlags(flags, bigNumberWorkaround);
 
 			let getType = {
 				'addresses': isAccountQuery,
@@ -81,9 +60,8 @@ module.exports = function listCommand(vorpal) {
 				'transactions': isTransactionQuery
 			};
 
-			let calls = fixedCommands.map(function (input) {
-				let output = getType[userInput.type](input);
-				return output;
+			let calls = userInput.variadic.map(function (input) {
+				return getType[userInput.type](input);
 			});
 
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "file-system": "^2.2.2",
     "fs-extra": "^3.0.1",
     "lisk-js": "^0.4.1",
-    "vorpal": "^1.12.0"
+    "vorpal": "LiskHQ/vorpal#master"
   }
 }

--- a/test/commands/get.js
+++ b/test/commands/get.js
@@ -57,7 +57,7 @@ describe('lisky get command palette', () => {
 
 		executeCommand(command, function (result) {
 			(result._command.args.type).should.be.equal('block');
-			(result._command.args.input).should.be.equal(261210776798678785);
+			(result._command.args.input).should.be.equal('261210776798678785');
 			done();
 		});
 
@@ -81,7 +81,7 @@ describe('lisky get command palette', () => {
 
 		executeCommand(command, function (result) {
 			(result._command.args.type).should.be.equal('transaction');
-			(result._command.args.input).should.be.equal(3641049113933914102);
+			(result._command.args.input).should.be.equal('3641049113933914102');
 			done();
 		});
 


### PR DESCRIPTION
Replace `Number(arg)` with `arg.toString()` through vorpal -> minimist in order to manage numbers greater than `MAX_SAFE_INTEGER` for javascript
Fixes #21 