### PR TITLE
Add sign transaction command - Closes #406

### DIFF
--- a/src/commands/signTransaction.js
+++ b/src/commands/signTransaction.js
@@ -1,0 +1,73 @@
+/*
+ * LiskHQ/lisky
+ * Copyright © 2017 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import cryptoModule from '../utils/cryptoModule';
+import { ValidationError } from '../utils/error';
+import { createCommand } from '../utils/helpers';
+import getInputsFromSources from '../utils/input';
+import commonOptions from '../utils/options';
+
+const description = `Sign a transaction using your secret passphrase.
+
+	Example: sign transaction '{"amount":"100","recipientId":"13356260975429434553L","senderPublicKey":null,"timestamp":52871598,"type":0,"fee":"10000000","recipientPublicKey":null,"asset":{}}'
+`;
+
+const handleErrors = error => {
+	if (error.message.match(/Unexpected token . in JSON/)) {
+		throw new ValidationError('Transaction was not valid JSON.');
+	}
+	throw error;
+};
+
+const processInputs = transaction => ({ passphrase, data }) => {
+	const transactionObject = JSON.parse(transaction || data);
+	return cryptoModule.signTransaction({
+		transaction: transactionObject,
+		passphrase,
+	});
+};
+
+export const actionCreator = vorpal => async ({ transaction, options }) => {
+	const transactionSource = options.transaction;
+	const passphraseSource = options.passphrase;
+
+	if (!transaction && !transactionSource) {
+		throw new ValidationError('No transaction was provided.');
+	}
+
+	return getInputsFromSources(vorpal, {
+		passphrase: {
+			source: passphraseSource,
+			repeatPrompt: true,
+		},
+		data: transaction
+			? null
+			: {
+					source: transactionSource,
+				},
+	})
+		.then(processInputs(transaction))
+		.catch(handleErrors);
+};
+
+const signTransaction = createCommand({
+	command: 'sign transaction [transaction]',
+	description,
+	actionCreator,
+	options: [commonOptions.passphrase, commonOptions.transaction],
+	errorPrefix: 'Could not sign transaction',
+});
+
+export default signTransaction;

--- a/src/utils/cryptoModule.js
+++ b/src/utils/cryptoModule.js
@@ -36,6 +36,7 @@ class Crypto {
 			'getKeys',
 			'getAddressFromPublicKey',
 			'signMessage',
+			'signTransaction',
 		].forEach(methodName => {
 			this[methodName] = wrapFunction(this[methodName].bind(this));
 		});
@@ -85,6 +86,14 @@ class Crypto {
 
 	signMessage({ message, passphrase }) {
 		return this.liskCrypto.signMessageWithPassphrase(message, passphrase);
+	}
+
+	// eslint-disable-next-line class-methods-use-this
+	signTransaction({ transaction, passphrase }) {
+		return liskJS.transaction.utils.signRawTransaction({
+			transaction,
+			passphrase,
+		});
 	}
 }
 

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -59,6 +59,15 @@ const testnetDescription = `Specifies whether to run the command against the tes
 	- --testnet false (runs against mainnet)
 `;
 
+const transactionDescription = `Specifies a source for providing a transaction to the command. If a string is provided directly as an argument, this option will be ignored. The transaction must be provided via an argument or via this option. Sources must be one of \`file\` or \`stdin\`. In the case of \`file\`, a corresponding identifier must also be provided.
+
+Note: if both secret passphrase and transaction are passed via stdin, the passphrase must be the first line.
+
+	Examples:
+	- --transaction file:/path/to/my/transaction.txt
+	- --transaction stdin
+`;
+
 const votesDescription = `Specifies the public keys for the delegate candidates you want to vote for. Takes either a string of public keys separated by commas, or a path to a file which contains the public keys.
 
 	Examples:
@@ -85,6 +94,7 @@ const options = {
 	pretty: ['--pretty', prettyDescription],
 	table: ['-t, --table', tableDescription],
 	testnet: ['--testnet', testnetDescription],
+	transaction: ['--transaction', transactionDescription],
 	unvotes: ['--unvotes <source...>', unvotesDescription],
 	votes: ['--votes <source...>', votesDescription],
 };

--- a/test/specs/commands/signTransaction.js
+++ b/test/specs/commands/signTransaction.js
@@ -1,0 +1,297 @@
+/*
+ * LiskHQ/lisky
+ * Copyright © 2017 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { setUpCommandSignTransaction } from '../../steps/setup';
+import * as given from '../../steps/1_given';
+import * as when from '../../steps/2_when';
+import * as then from '../../steps/3_then';
+
+describe('sign transaction command', () => {
+	beforeEach(setUpCommandSignTransaction);
+	Given(
+		'a Vorpal instance with a UI and an active command that can prompt',
+		given.aVorpalInstanceWithAUIAndAnActiveCommandThatCanPrompt,
+		() => {
+			Given(
+				'a crypto instance has been initialised',
+				given.aCryptoInstanceHasBeenInitialised,
+				() => {
+					Given('an action "sign transaction"', given.anAction, () => {
+						Given(
+							'a passphrase "minute omit local rare sword knee banner pair rib museum shadow juice"',
+							given.aPassphrase,
+							() => {
+								Given(
+									'an invalid transaction JSON string "not json"',
+									given.anInvalidTransactionJSONString,
+									() => {
+										Given(
+											'an empty options object',
+											given.anEmptyOptionsObject,
+											() => {
+												When(
+													'the action is called with the transaction and the options',
+													when.theActionIsCalledWithTheTransactionAndTheOptions,
+													() => {
+														Then(
+															'it should reject with validation error and message "Transaction was not valid JSON."',
+															then.itShouldRejectWithValidationErrorAndMessage,
+														);
+													},
+												);
+											},
+										);
+									},
+								);
+								Given(
+									'an unsigned transaction \'{"amount":"100","recipientId":"13356260975429434553L","senderPublicKey":null,"timestamp":52871598,"type":0,"fee":"10000000","recipientPublicKey":null,"asset":{}}\'',
+									given.anUnsignedTransaction,
+									() => {
+										Given(
+											'an empty options object',
+											given.anEmptyOptionsObject,
+											() => {
+												When(
+													'the action is called with the options',
+													when.theActionIsCalledWithTheOptions,
+													() => {
+														Then(
+															'it should reject with validation error and message "No transaction was provided."',
+															then.itShouldRejectWithValidationErrorAndMessage,
+														);
+													},
+												);
+												Given(
+													'an error "Unknown data source type." occurs retrieving the inputs from their sources',
+													given.anErrorOccursRetrievingTheInputsFromTheirSources,
+													() => {
+														When(
+															'the action is called with the transaction and the options',
+															when.theActionIsCalledWithTheTransactionAndTheOptions,
+															() => {
+																Then(
+																	'it should reject with the error message',
+																	then.itShouldRejectWithTheErrorMessage,
+																);
+															},
+														);
+													},
+												);
+												Given(
+													'the passphrase can be retrieved from its source',
+													given.thePassphraseCanBeRetrievedFromItsSource,
+													() => {
+														When(
+															'the action is called with the transaction and the options',
+															when.theActionIsCalledWithTheTransactionAndTheOptions,
+															() => {
+																Then(
+																	'it should get the inputs from sources using the Vorpal instance',
+																	then.itShouldGetTheInputsFromSourcesUsingTheVorpalInstance,
+																);
+																Then(
+																	'it should get the inputs from sources using the passphrase source with a repeating prompt',
+																	then.itShouldGetTheInputsFromSourcesUsingThePassphraseSourceWithARepeatingPrompt,
+																);
+																Then(
+																	'it should not get the inputs from sources using the transaction source',
+																	then.itShouldNotGetTheInputsFromSourcesUsingTheTransactionSource,
+																);
+																Then(
+																	'it should sign the transaction with the passphrase',
+																	then.itShouldSignTheTransactionWithThePassphrase,
+																);
+																Then(
+																	'it should resolve to the result of signing the transaction',
+																	then.itShouldResolveToTheResultOfSigningTheTransaction,
+																);
+															},
+														);
+													},
+												);
+											},
+										);
+										Given(
+											'an options object with passphrase set to "passphraseSource"',
+											given.anOptionsObjectWithPassphraseSetTo,
+											() => {
+												Given(
+													'an error "Unknown data source type." occurs retrieving the inputs from their sources',
+													given.anErrorOccursRetrievingTheInputsFromTheirSources,
+													() => {
+														When(
+															'the action is called with the transaction and the options',
+															when.theActionIsCalledWithTheTransactionAndTheOptions,
+															() => {
+																Then(
+																	'it should reject with the error message',
+																	then.itShouldRejectWithTheErrorMessage,
+																);
+															},
+														);
+													},
+												);
+												Given(
+													'the passphrase can be retrieved from its source',
+													given.thePassphraseCanBeRetrievedFromItsSource,
+													() => {
+														When(
+															'the action is called with the transaction and the options',
+															when.theActionIsCalledWithTheTransactionAndTheOptions,
+															() => {
+																Then(
+																	'it should get the inputs from sources using the Vorpal instance',
+																	then.itShouldGetTheInputsFromSourcesUsingTheVorpalInstance,
+																);
+																Then(
+																	'it should get the inputs from sources using the passphrase source with a repeating prompt',
+																	then.itShouldGetTheInputsFromSourcesUsingThePassphraseSourceWithARepeatingPrompt,
+																);
+																Then(
+																	'it should not get the inputs from sources using the transaction source',
+																	then.itShouldNotGetTheInputsFromSourcesUsingTheTransactionSource,
+																);
+																Then(
+																	'it should sign the transaction with the passphrase',
+																	then.itShouldSignTheTransactionWithThePassphrase,
+																);
+																Then(
+																	'it should resolve to the result of signing the transaction',
+																	then.itShouldResolveToTheResultOfSigningTheTransaction,
+																);
+															},
+														);
+													},
+												);
+											},
+										);
+										Given(
+											'an options object with transaction set to "transactionSource"',
+											given.anOptionsObjectWithTransactionSetTo,
+											() => {
+												Given(
+													'an error "Unknown data source type." occurs retrieving the inputs from their sources',
+													given.anErrorOccursRetrievingTheInputsFromTheirSources,
+													() => {
+														When(
+															'the action is called with the transaction and the options',
+															when.theActionIsCalledWithTheTransactionAndTheOptions,
+															() => {
+																Then(
+																	'it should reject with the error message',
+																	then.itShouldRejectWithTheErrorMessage,
+																);
+															},
+														);
+													},
+												);
+												Given(
+													'the passphrase and transaction can be retrieved from their sources',
+													given.thePassphraseAndTransactionCanBeRetrievedFromTheirSources,
+													() => {
+														When(
+															'the action is called with the options',
+															when.theActionIsCalledWithTheOptions,
+															() => {
+																Then(
+																	'it should get the inputs from sources using the Vorpal instance',
+																	then.itShouldGetTheInputsFromSourcesUsingTheVorpalInstance,
+																);
+																Then(
+																	'it should get the inputs from sources using the passphrase source with a repeating prompt',
+																	then.itShouldGetTheInputsFromSourcesUsingThePassphraseSourceWithARepeatingPrompt,
+																);
+																Then(
+																	'it should get the inputs from sources using the transaction source',
+																	then.itShouldGetTheInputsFromSourcesUsingTheTransactionSource,
+																);
+																Then(
+																	'it should sign the transaction with the passphrase',
+																	then.itShouldSignTheTransactionWithThePassphrase,
+																);
+																Then(
+																	'it should resolve to the result of signing the transaction',
+																	then.itShouldResolveToTheResultOfSigningTheTransaction,
+																);
+															},
+														);
+													},
+												);
+											},
+										);
+										Given(
+											'an options object with passphrase set to "passphraseSource" and transaction set to "transactionSource"',
+											given.anOptionsObjectWithPassphraseSetToAndTransactionSetTo,
+											() => {
+												Given(
+													'an error "Unknown data source type." occurs retrieving the inputs from their sources',
+													given.anErrorOccursRetrievingTheInputsFromTheirSources,
+													() => {
+														When(
+															'the action is called with the transaction and the options',
+															when.theActionIsCalledWithTheTransactionAndTheOptions,
+															() => {
+																Then(
+																	'it should reject with the error message',
+																	then.itShouldRejectWithTheErrorMessage,
+																);
+															},
+														);
+													},
+												);
+												Given(
+													'the passphrase and transaction can be retrieved from their sources',
+													given.thePassphraseAndTransactionCanBeRetrievedFromTheirSources,
+													() => {
+														When(
+															'the action is called with the options',
+															when.theActionIsCalledWithTheOptions,
+															() => {
+																Then(
+																	'it should get the inputs from sources using the Vorpal instance',
+																	then.itShouldGetTheInputsFromSourcesUsingTheVorpalInstance,
+																);
+																Then(
+																	'it should get the inputs from sources using the passphrase source with a repeating prompt',
+																	then.itShouldGetTheInputsFromSourcesUsingThePassphraseSourceWithARepeatingPrompt,
+																);
+																Then(
+																	'it should get the inputs from sources using the transaction source',
+																	then.itShouldGetTheInputsFromSourcesUsingTheTransactionSource,
+																);
+																Then(
+																	'it should sign the transaction with the passphrase',
+																	then.itShouldSignTheTransactionWithThePassphrase,
+																);
+																Then(
+																	'it should resolve to the result of signing the transaction',
+																	then.itShouldResolveToTheResultOfSigningTheTransaction,
+																);
+															},
+														);
+													},
+												);
+											},
+										);
+									},
+								);
+							},
+						);
+					});
+				},
+			);
+		},
+	);
+});

--- a/test/specs/utils/cryptoModule.js
+++ b/test/specs/utils/cryptoModule.js
@@ -148,31 +148,36 @@ describe('Crypto class', () => {
 				});
 				Given('a message "Hello Lisker"', given.aMessage, () => {
 					describe('#signMessage', () => {
-						describe('Given the message under the passphrase has signature "H+9koLx4AZoEupc1z5TBQDaDkI9KQu1QDPXWXxzVvhaXGDi/2BD0qypVJu596CrZ+XHuUAdx2wLZgyN/ZfqfAQ=="', () => {
-							beforeEach(given.theMessageUnderThePassphraseHasSignature);
-							describe('When no error occurs attempting to sign the message using the passphrase', () => {
-								beforeEach(
+						Given(
+							'the message under the passphrase has signature "H+9koLx4AZoEupc1z5TBQDaDkI9KQu1QDPXWXxzVvhaXGDi/2BD0qypVJu596CrZ+XHuUAdx2wLZgyN/ZfqfAQ=="',
+							given.theMessageUnderThePassphraseHasSignature,
+							() => {
+								When(
+									'no error occurs attempting to sign the message using the passphrase',
 									when.noErrorOccursAttemptingToSignTheMessageUsingThePassphrase,
+									() => {
+										Then(
+											'lisk-js crypto should be used to sign the message',
+											then.liskJSCryptoShouldBeUsedToSignTheMessage,
+										);
+										Then(
+											'the signature should be returned',
+											then.theSignatureShouldBeReturned,
+										);
+									},
 								);
-								it(
-									'Then lisk-js crypto should be used to sign the message',
-									then.liskJSCryptoShouldBeUsedToSignTheMessage,
-								);
-								it(
-									'Then the signature should be returned',
-									then.theSignatureShouldBeReturned,
-								);
-							});
-							describe('When an error occurs attempting to sign the message using the passphrase', () => {
-								beforeEach(
+								When(
+									'an error occurs attempting to sign the message using the passphrase',
 									when.anErrorOccursAttemptingToSignTheMessageUsingThePassphrase,
+									() => {
+										Then(
+											'the error response should be handled',
+											then.theErrorResponseShouldBeHandled,
+										);
+									},
 								);
-								it(
-									'Then the error response should be handled',
-									then.theErrorResponseShouldBeHandled,
-								);
-							});
-						});
+							},
+						);
 					});
 					Given(
 						'a recipient passphrase "polar save winner any focus slide runway ghost finish invite regret laugh" with private key "08595f178e7470ad2cbe054b29f60311a0f808be969cde6c274819580a428dcd31919b459d28b1c611afb4db3de95c5769f4891c3f771c7dbcb53a45c452cc25" and public key "31919b459d28b1c611afb4db3de95c5769f4891c3f771c7dbcb53a45c452cc25"',
@@ -234,6 +239,24 @@ describe('Crypto class', () => {
 											},
 										);
 									});
+								},
+							);
+						},
+					);
+				});
+				describe('#signTransaction', () => {
+					Given(
+						'an unsigned transaction \'{"amount":"100","recipientId":"13356260975429434553L","senderPublicKey":null,"timestamp":52871598,"type":0,"fee":"10000000","recipientPublicKey":null,"asset":{}}\'',
+						given.anUnsignedTransaction,
+						() => {
+							When(
+								'no error occurs attempting to sign the transaction using the passphrase',
+								when.noErrorOccursAttemptingToSignTheTransactionUsingThePassphrase,
+								() => {
+									Then(
+										'the signed transaction should be returned',
+										then.theSignedTransactionShouldBeReturned,
+									);
 								},
 							);
 						},

--- a/test/steps/crypto/1_given.js
+++ b/test/steps/crypto/1_given.js
@@ -40,6 +40,7 @@ export function aCryptoInstanceHasBeenInitialised() {
 		'getKeys',
 		'getAddressFromPublicKey',
 		'signMessage',
+		'signTransaction',
 	].forEach(methodName => cryptoInstance[methodName].returns(cryptoResult));
 
 	this.test.ctx.cryptoResult = cryptoResult;

--- a/test/steps/crypto/2_when.js
+++ b/test/steps/crypto/2_when.js
@@ -16,6 +16,17 @@
 import lisk from 'lisk-js';
 import { DEFAULT_ERROR_MESSAGE } from '../utils';
 
+export function noErrorOccursAttemptingToSignTheTransactionUsingThePassphrase() {
+	const { cryptoInstance, transaction, passphrase } = this.test.ctx;
+
+	// NOTE: Stubbing an exported function is not possible, otherwise we would do so here.
+
+	this.test.ctx.returnValue = cryptoInstance.signTransaction({
+		transaction,
+		passphrase,
+	});
+}
+
 export function noErrorOccursAttemptingToSignTheMessageUsingThePassphrase() {
 	const { cryptoInstance, message, passphrase, signature } = this.test.ctx;
 

--- a/test/steps/crypto/3_then.js
+++ b/test/steps/crypto/3_then.js
@@ -25,7 +25,20 @@ export function itShouldSignTheMessageWithThePassphrase() {
 	});
 }
 
+export function itShouldSignTheTransactionWithThePassphrase() {
+	const { transaction, passphrase } = this.test.ctx;
+	return cryptoInstance.signTransaction.should.be.calledWithExactly({
+		transaction,
+		passphrase,
+	});
+}
+
 export function itShouldResolveToTheResultOfSigningTheMessage() {
+	const { returnValue, cryptoResult } = this.test.ctx;
+	return returnValue.should.be.fulfilledWith(cryptoResult);
+}
+
+export function itShouldResolveToTheResultOfSigningTheTransaction() {
 	const { returnValue, cryptoResult } = this.test.ctx;
 	return returnValue.should.be.fulfilledWith(cryptoResult);
 }

--- a/test/steps/crypto/3_then.js
+++ b/test/steps/crypto/3_then.js
@@ -113,6 +113,18 @@ export function theSignatureShouldBeReturned() {
 	return returnValue.should.be.eql(signature);
 }
 
+export function theSignedTransactionShouldBeReturned() {
+	const { returnValue, transaction } = this.test.ctx;
+	const expectedKeys = [
+		...Object.keys(transaction),
+		'id',
+		'signature',
+		'senderId',
+		'senderSecondPublicKey',
+	];
+	return Object.keys(returnValue).should.containDeep(expectedKeys);
+}
+
 export function liskJSCryptoShouldBeUsedToSignTheMessage() {
 	const { message, passphrase } = this.test.ctx;
 	return lisk.crypto.signMessageWithPassphrase.should.be.calledWithExactly(

--- a/test/steps/inputs/1_given.js
+++ b/test/steps/inputs/1_given.js
@@ -125,6 +125,16 @@ export function thePassphraseAndMessageCanBeRetrievedFromTheirSources() {
 	});
 }
 
+export function thePassphraseAndTransactionCanBeRetrievedFromTheirSources() {
+	const { passphrase, transactionString } = this.test.ctx;
+	getInputsFromSources.resolves({
+		passphrase,
+		secondPassphrase: null,
+		password: null,
+		data: transactionString,
+	});
+}
+
 export function thePasswordIsProvidedViaStdIn() {
 	const { password } = this.test.ctx;
 

--- a/test/steps/inputs/3_then.js
+++ b/test/steps/inputs/3_then.js
@@ -126,7 +126,20 @@ export function itShouldGetTheInputsFromSourcesUsingTheMessageSource() {
 	});
 }
 
+export function itShouldGetTheInputsFromSourcesUsingTheTransactionSource() {
+	const { options } = this.test.ctx;
+	const firstCallArgs = getInputsFromSources.firstCall.args;
+	return firstCallArgs[1].should.have.property('data').eql({
+		source: options.transaction,
+	});
+}
+
 export function itShouldNotGetTheInputsFromSourcesUsingTheMessageSource() {
+	const firstCallArgs = getInputsFromSources.firstCall.args;
+	return firstCallArgs[1].should.have.property('data').be.null();
+}
+
+export function itShouldNotGetTheInputsFromSourcesUsingTheTransactionSource() {
 	const firstCallArgs = getInputsFromSources.firstCall.args;
 	return firstCallArgs[1].should.have.property('data').be.null();
 }

--- a/test/steps/options/1_given.js
+++ b/test/steps/options/1_given.js
@@ -135,9 +135,24 @@ export function anOptionsObjectWithPassphraseSetToAndMessageSetTo() {
 	};
 }
 
+export function anOptionsObjectWithPassphraseSetToAndTransactionSetTo() {
+	const [passphraseSource, transactionSource] = getQuotedStrings(
+		this.test.parent.title,
+	);
+	this.test.ctx.options = {
+		passphrase: passphraseSource,
+		transaction: transactionSource,
+	};
+}
+
 export function anOptionsObjectWithMessageSetTo() {
 	const message = getFirstQuotedString(this.test.parent.title);
 	this.test.ctx.options = { message };
+}
+
+export function anOptionsObjectWithTransactionSetTo() {
+	const transaction = getFirstQuotedString(this.test.parent.title);
+	this.test.ctx.options = { transaction };
 }
 
 export function anOptionsObjectWithPassphraseSetTo() {

--- a/test/steps/setup.js
+++ b/test/steps/setup.js
@@ -117,6 +117,7 @@ const setUpCryptoStubs = () => {
 		'getKeys',
 		'getAddressFromPublicKey',
 		'signMessage',
+		'signTransaction',
 	].forEach(methodName => sandbox.stub(cryptoInstance, methodName));
 };
 
@@ -268,6 +269,11 @@ export function tearDownCommandSet() {
 }
 
 export function setUpCommandSignMessage() {
+	setUpCryptoStubs();
+	setUpInputStubs();
+}
+
+export function setUpCommandSignTransaction() {
 	setUpCryptoStubs();
 	setUpInputStubs();
 }

--- a/test/steps/transactions/1_given.js
+++ b/test/steps/transactions/1_given.js
@@ -65,12 +65,19 @@ export function aTransactionInStringifiedJSONFormat() {
 	});
 }
 
+export function anInvalidTransactionJSONString() {
+	this.test.ctx.transactionString = getFirstQuotedString(
+		this.test.parent.title,
+	);
+}
+
 export function aTransactionsObject() {
 	this.test.ctx.transactionsObject = transactions;
 }
 
 export function anUnsignedTransaction() {
 	const transactionString = getFirstQuotedString(this.test.parent.title);
+	this.test.ctx.transactionString = transactionString;
 	this.test.ctx.transaction = JSON.parse(transactionString);
 }
 

--- a/test/steps/transactions/1_given.js
+++ b/test/steps/transactions/1_given.js
@@ -14,6 +14,7 @@
  *
  */
 import transactions from '../../../src/utils/transactions';
+import { getFirstQuotedString } from '../utils';
 
 export function aSignatureInTableFormat() {
 	this.test.ctx.signature = `
@@ -68,13 +69,17 @@ export function aTransactionsObject() {
 	this.test.ctx.transactionsObject = transactions;
 }
 
+export function anUnsignedTransaction() {
+	const transactionString = getFirstQuotedString(this.test.parent.title);
+	this.test.ctx.transaction = JSON.parse(transactionString);
+}
+
 export function aLiskObjectThatCanCreateTransactions() {
 	const createdTransaction = {
 		type: 0,
 		amount: 123,
 		publicKey: 'oneStubbedPublicKey',
 	};
-
 	[
 		'transfer',
 		'registerSecondPassphrase',

--- a/test/steps/utils.js
+++ b/test/steps/utils.js
@@ -32,6 +32,7 @@ import * as set from '../../src/commands/set';
 import * as showCopyright from '../../src/commands/showCopyright';
 import * as showWarranty from '../../src/commands/showWarranty';
 import * as signMessage from '../../src/commands/signMessage';
+import * as signTransaction from '../../src/commands/signTransaction';
 
 export const DEFAULT_ERROR_MESSAGE = "Cannot read property 'length' of null";
 
@@ -95,6 +96,7 @@ export const getActionCreator = actionName =>
 		'show copyright': showCopyright.actionCreator,
 		'show warranty': showWarranty.actionCreator,
 		'sign message': signMessage.actionCreator,
+		'sign transaction': signTransaction.actionCreator,
 	}[actionName]);
 
 export const createFakeInterface = value => ({

--- a/test/steps/utils.js
+++ b/test/steps/utils.js
@@ -40,15 +40,15 @@ const BOOLEANS = {
 	false: false,
 };
 
-const regExpQuotes = /"((.|\n|\s\S)+?)"/;
+const regExpQuotes = /(["'])((.|\n|[^\\s\S])+?)\1/;
 const regExpNumbers = /\d+(.\d+)?/;
 const regExpBooleans = /(true|false)/;
 
-export const getFirstQuotedString = title => title.match(regExpQuotes)[1];
+export const getFirstQuotedString = title => title.match(regExpQuotes)[2];
 
 export const getQuotedStrings = title => {
 	const globalRegExp = new RegExp(regExpQuotes, 'g');
-	return title.match(globalRegExp).map(match => match.match(regExpQuotes)[1]);
+	return title.match(globalRegExp).map(match => match.match(regExpQuotes)[2]);
 };
 
 export const getFirstNumber = title => Number(title.match(regExpNumbers)[0]);

--- a/test/steps/vorpal/2_when.js
+++ b/test/steps/vorpal/2_when.js
@@ -98,6 +98,16 @@ export function theActionIsCalledWithTheMessageAndTheOptions() {
 	return returnValue.catch(e => e);
 }
 
+export function theActionIsCalledWithTheTransactionAndTheOptions() {
+	const { action, transactionString, options } = this.test.ctx;
+	const returnValue = action({
+		transaction: transactionString,
+		options,
+	});
+	this.test.ctx.returnValue = returnValue;
+	return returnValue.catch(e => e);
+}
+
 export function theActionIsCalledWithTheDelegateUsernameAndTheOptions() {
 	const { action, delegateUsername: username, options } = this.test.ctx;
 	const returnValue = action({ username, options });


### PR DESCRIPTION
Closes #406 

Things to think about when reviewing:

1. I followed the pattern of `sign message` where a transaction can be provided as an argument, or as an option via a file/`process.stdin`, rather than the pattern of `broadcast transaction` which is expecting to receive input from another command.
1. The `signRawTransaction` transaction util from LiskJS could not be stubbed straightforwardly because of the way Babel handles re-exporting functions. So the testing in the crypto module departs from the pattern established elsewhere.
1. This is also the first time the crypto module has incorporated functionality from outside LiskJS's crypto module. I thought in the context of Lisky it made sense to include it in the crypto module to keep things uniform, even though an ESLint rule regarding class methods using `this` was overridden. I'm open to other suggestions here.
1. Tests got a bit complicated because of confusion between transaction objects and strings.
1. I haven't implemented second passphrase yet, thought I'd get some feedback on the structure first.