### PR TITLE
Fix recursive to have limit and catch failed API - Closes #452

### DIFF
--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -15,16 +15,27 @@
  */
 import liskAPIInstance from './api';
 
-const handleErrorResponse = (response) => {
-	if (!response.success) {
-		return Promise.reject(new Error(response.message));
-	}
-	return response;
+const wrapFunction = fn => function wrappedFunction(...args) {
+	return fn(...args)
+		.then((response) => {
+			if (!response.success) {
+				return Promise.reject(new Error(response.message));
+			}
+			return response;
+		});
 };
 
 class Query {
 	constructor() {
 		this.client = liskAPIInstance;
+		[
+			'getBlock',
+			'getAccount',
+			'getTransaction',
+			'getDelegate',
+		].forEach((methodName) => {
+			this[methodName] = wrapFunction(this[methodName].bind(this));
+		});
 		this.handlers = {
 			account: account => this.getAccount(account),
 			block: block => this.getBlock(block),
@@ -34,23 +45,19 @@ class Query {
 	}
 
 	getBlock(input) {
-		return this.client.sendRequest('blocks/get', { id: input })
-			.then(handleErrorResponse);
+		return this.client.sendRequest('blocks/get', { id: input });
 	}
 
 	getAccount(input) {
-		return this.client.sendRequest('accounts', { address: input })
-			.then(handleErrorResponse);
+		return this.client.sendRequest('accounts', { address: input });
 	}
 
 	getTransaction(input) {
-		return this.client.sendRequest('transactions/get', { id: input })
-			.then(handleErrorResponse);
+		return this.client.sendRequest('transactions/get', { id: input });
 	}
 
 	getDelegate(input) {
-		return this.client.sendRequest('delegates/get', { username: input })
-			.then(handleErrorResponse);
+		return this.client.sendRequest('delegates/get', { username: input });
 	}
 }
 

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -15,6 +15,13 @@
  */
 import liskAPIInstance from './api';
 
+const handleErrorResponse = (response) => {
+	if (!response.success) {
+		return Promise.reject(new Error(response.message));
+	}
+	return response;
+};
+
 class Query {
 	constructor() {
 		this.client = liskAPIInstance;
@@ -27,19 +34,23 @@ class Query {
 	}
 
 	getBlock(input) {
-		return this.client.sendRequest('blocks/get', { id: input });
+		return this.client.sendRequest('blocks/get', { id: input })
+			.then(handleErrorResponse);
 	}
 
 	getAccount(input) {
-		return this.client.sendRequest('accounts', { address: input });
+		return this.client.sendRequest('accounts', { address: input })
+			.then(handleErrorResponse);
 	}
 
 	getTransaction(input) {
-		return this.client.sendRequest('transactions/get', { id: input });
+		return this.client.sendRequest('transactions/get', { id: input })
+			.then(handleErrorResponse);
 	}
 
 	getDelegate(input) {
-		return this.client.sendRequest('delegates/get', { username: input });
+		return this.client.sendRequest('delegates/get', { username: input })
+			.then(handleErrorResponse);
 	}
 }
 

--- a/src/utils/tablify.js
+++ b/src/utils/tablify.js
@@ -42,7 +42,8 @@ const addValuesToTable = (table, data) => {
 	const valuesToPush = nestedValues.map((value) => {
 		if (Array.isArray(value)) {
 			return value.join('\n');
-		} else if (value && typeof value === 'object') {
+		}
+		if (value && typeof value === 'object') {
 			try {
 				return JSON.stringify(value);
 			} catch (e) {

--- a/src/utils/tablify.js
+++ b/src/utils/tablify.js
@@ -33,6 +33,8 @@ const chars = {
 	middle: '│',
 };
 
+const errorCyclicObject = 'Error: cyclic object cannot be displayed.';
+
 const getNestedValue = data => keyString => keyString.split('.').reduce((obj, key) => obj[key], data);
 
 const addValuesToTable = (table, data) => {
@@ -41,7 +43,11 @@ const addValuesToTable = (table, data) => {
 		if (Array.isArray(value)) {
 			return value.join('\n');
 		} else if (value && typeof value === 'object') {
-			return JSON.stringify(value);
+			try {
+				return JSON.stringify(value);
+			} catch (e) {
+				return errorCyclicObject;
+			}
 		}
 		return value;
 	});

--- a/test/specs/utils/query.js
+++ b/test/specs/utils/query.js
@@ -27,56 +27,56 @@ describe('Query class', () => {
 			Then('the query instance should have a handler for "transaction"', then.theQueryInstanceShouldHaveAHandlerFor);
 			describe('#getBlock', () => {
 				Given('a block ID "5650160629533476718"', given.aBlockID, () => {
-					When('request is successful', when.sendRequestSuccesses, () => {
+					When('the request is successful', when.theRequestIsSuccessful, () => {
 						When('the query instance gets a block using the ID', when.theQueryInstanceGetsABlockUsingTheID, () => {
-							Then('the lisk instance should send a request to the blocks/get API endpoint with the block ID', then.theLiskAPIInstanceShouldSendARequestToTheBlocksGetAPIEndpointWithTheBlockID);
+							Then('the lisk API instance should send a request to the "blocks/get" API endpoint with the block ID', then.theLiskAPIInstanceShouldSendARequestToTheBlocksGetAPIEndpointWithTheBlockID);
 						});
 					});
-					When('request fails', when.sendRequestFails, () => {
+					When('the request fails', when.theRequestFails, () => {
 						When('the query instance gets a block using the ID', when.theQueryInstanceGetsABlockUsingTheID, () => {
-							Then('the query should be rejected with an error message', then.itShouldRejectWithTheErrorMessage);
+							Then('it should reject with the error message', then.itShouldRejectWithTheErrorMessage);
 						});
 					});
 				});
 			});
 			describe('#getAccount', () => {
 				Given('an address "13782017140058682841L"', given.anAddress, () => {
-					When('request is successful', when.sendRequestSuccesses, () => {
+					When('the request is successful', when.theRequestIsSuccessful, () => {
 						When('the query instance gets an account using the address', when.theQueryInstanceGetsAnAccountUsingTheAddress, () => {
-							Then('the lisk instance should send a request to the accounts API endpoint with the address', then.theLiskAPIInstanceShouldSendARequestToTheAccountsAPIEndpointWithTheAddress);
+							Then('the lisk API instance should send a request to the "accounts" API endpoint with the address', then.theLiskAPIInstanceShouldSendARequestToTheAccountsAPIEndpointWithTheAddress);
 						});
 					});
-					When('request fails', when.sendRequestFails, () => {
+					When('the request fails', when.theRequestFails, () => {
 						When('the query instance gets an account using the address', when.theQueryInstanceGetsAnAccountUsingTheAddress, () => {
-							Then('the query should be rejected with an error message', then.itShouldRejectWithTheErrorMessage);
+							Then('it should reject with the error message', then.itShouldRejectWithTheErrorMessage);
 						});
 					});
 				});
 			});
 			describe('#getTransaction', () => {
 				Given('a transaction ID "16388447461355055139"', given.aTransactionID, () => {
-					When('request is successful', when.sendRequestSuccesses, () => {
+					When('the request is successful', when.theRequestIsSuccessful, () => {
 						When('the query instance gets a transaction using the ID', when.theQueryInstanceGetsATransactionUsingTheID, () => {
-							Then('the lisk instance should send a request to the transactions/get API endpoint with the transaction ID', then.theLiskAPIInstanceShouldSendARequestToTheTransactionsGetAPIEndpointWithTheTransactionID);
+							Then('the lisk API instance should send a request to the "transactions/get" API endpoint with the transaction ID', then.theLiskAPIInstanceShouldSendARequestToTheTransactionsGetAPIEndpointWithTheTransactionID);
 						});
 					});
-					When('request fails', when.sendRequestFails, () => {
+					When('the request fails', when.theRequestFails, () => {
 						When('the query instance gets a transaction using the ID', when.theQueryInstanceGetsATransactionUsingTheID, () => {
-							Then('the query should be rejected with an error message', then.itShouldRejectWithTheErrorMessage);
+							Then('it should reject with the error message', then.itShouldRejectWithTheErrorMessage);
 						});
 					});
 				});
 			});
 			describe('#getDelegate', () => {
 				Given('a delegate username "lightcurve"', given.aDelegateUsername, () => {
-					When('request is successful', when.sendRequestSuccesses, () => {
+					When('the request is successful', when.theRequestIsSuccessful, () => {
 						When('the query instance gets a delegate using the username', when.theQueryInstanceGetsADelegateUsingTheUsername, () => {
-							Then('the lisk instance should send a request to the delegates/get API endpoint with the username', then.theLiskAPIInstanceShouldSendARequestToTheDelegatesGetAPIEndpointWithTheUsername);
+							Then('the lisk API instance should send a request to the "delegates/get" API endpoint with the username', then.theLiskAPIInstanceShouldSendARequestToTheDelegatesGetAPIEndpointWithTheUsername);
 						});
 					});
-					When('request fails', when.sendRequestFails, () => {
+					When('the request fails', when.theRequestFails, () => {
 						When('the query instance gets a delegate using the username', when.theQueryInstanceGetsADelegateUsingTheUsername, () => {
-							Then('the query should be rejected with an error message', then.itShouldRejectWithTheErrorMessage);
+							Then('it should reject with the error message', then.itShouldRejectWithTheErrorMessage);
 						});
 					});
 				});

--- a/test/specs/utils/query.js
+++ b/test/specs/utils/query.js
@@ -27,29 +27,57 @@ describe('Query class', () => {
 			Then('the query instance should have a handler for "transaction"', then.theQueryInstanceShouldHaveAHandlerFor);
 			describe('#getBlock', () => {
 				Given('a block ID "5650160629533476718"', given.aBlockID, () => {
-					When('the query instance gets a block using the ID', when.theQueryInstanceGetsABlockUsingTheID, () => {
-						Then('the lisk instance should send a request to the blocks/get API endpoint with the block ID', then.theLiskAPIInstanceShouldSendARequestToTheBlocksGetAPIEndpointWithTheBlockID);
+					When('request is successful', when.sendRequestSuccesses, () => {
+						When('the query instance gets a block using the ID', when.theQueryInstanceGetsABlockUsingTheID, () => {
+							Then('the lisk instance should send a request to the blocks/get API endpoint with the block ID', then.theLiskAPIInstanceShouldSendARequestToTheBlocksGetAPIEndpointWithTheBlockID);
+						});
+					});
+					When('request fails', when.sendRequestFails, () => {
+						When('the query instance gets a block using the ID', when.theQueryInstanceGetsABlockUsingTheID, () => {
+							Then('the query should be rejected with an error message', then.itShouldRejectWithTheErrorMessage);
+						});
 					});
 				});
 			});
 			describe('#getAccount', () => {
 				Given('an address "13782017140058682841L"', given.anAddress, () => {
-					When('the query instance gets an account using the address', when.theQueryInstanceGetsAnAccountUsingTheAddress, () => {
-						Then('the lisk instance should send a request to the accounts API endpoint with the address', then.theLiskAPIInstanceShouldSendARequestToTheAccountsAPIEndpointWithTheAddress);
+					When('request is successful', when.sendRequestSuccesses, () => {
+						When('the query instance gets an account using the address', when.theQueryInstanceGetsAnAccountUsingTheAddress, () => {
+							Then('the lisk instance should send a request to the accounts API endpoint with the address', then.theLiskAPIInstanceShouldSendARequestToTheAccountsAPIEndpointWithTheAddress);
+						});
+					});
+					When('request fails', when.sendRequestFails, () => {
+						When('the query instance gets an account using the address', when.theQueryInstanceGetsAnAccountUsingTheAddress, () => {
+							Then('the query should be rejected with an error message', then.itShouldRejectWithTheErrorMessage);
+						});
 					});
 				});
 			});
 			describe('#getTransaction', () => {
 				Given('a transaction ID "16388447461355055139"', given.aTransactionID, () => {
-					When('the query instance gets a transaction using the ID', when.theQueryInstanceGetsATransactionUsingTheID, () => {
-						Then('the lisk instance should send a request to the transactions/get API endpoint with the transaction ID', then.theLiskAPIInstanceShouldSendARequestToTheTransactionsGetAPIEndpointWithTheTransactionID);
+					When('request is successful', when.sendRequestSuccesses, () => {
+						When('the query instance gets a transaction using the ID', when.theQueryInstanceGetsATransactionUsingTheID, () => {
+							Then('the lisk instance should send a request to the transactions/get API endpoint with the transaction ID', then.theLiskAPIInstanceShouldSendARequestToTheTransactionsGetAPIEndpointWithTheTransactionID);
+						});
+					});
+					When('request fails', when.sendRequestFails, () => {
+						When('the query instance gets a transaction using the ID', when.theQueryInstanceGetsATransactionUsingTheID, () => {
+							Then('the query should be rejected with an error message', then.itShouldRejectWithTheErrorMessage);
+						});
 					});
 				});
 			});
 			describe('#getDelegate', () => {
 				Given('a delegate username "lightcurve"', given.aDelegateUsername, () => {
-					When('the query instance gets a delegate using the username', when.theQueryInstanceGetsADelegateUsingTheUsername, () => {
-						Then('the lisk instance should send a request to the delegates/get API endpoint with the username', then.theLiskAPIInstanceShouldSendARequestToTheDelegatesGetAPIEndpointWithTheUsername);
+					When('request is successful', when.sendRequestSuccesses, () => {
+						When('the query instance gets a delegate using the username', when.theQueryInstanceGetsADelegateUsingTheUsername, () => {
+							Then('the lisk instance should send a request to the delegates/get API endpoint with the username', then.theLiskAPIInstanceShouldSendARequestToTheDelegatesGetAPIEndpointWithTheUsername);
+						});
+					});
+					When('request fails', when.sendRequestFails, () => {
+						When('the query instance gets a delegate using the username', when.theQueryInstanceGetsADelegateUsingTheUsername, () => {
+							Then('the query should be rejected with an error message', then.itShouldRejectWithTheErrorMessage);
+						});
 					});
 				});
 			});

--- a/test/specs/utils/tablify.js
+++ b/test/specs/utils/tablify.js
@@ -42,6 +42,12 @@ describe('tablify util', () => {
 			Then('the returned table should have a row with the object’s deeply nested values', then.theReturnedTableShouldHaveAHeadWithTheObjectDeeplyNestedValues);
 		});
 	});
+	Given('a cyclic object', given.aCyclicObject, () => {
+		When('the object is tablified', when.theObjectIsTablified, () => {
+			Then('the returned table should have a head with the cyclic object’s keys', then.theReturnedTableShouldHaveAHeadWithTheCyclicObjectKeys);
+			Then('the returned table should have a row with the cyclic object’s values and show error when cyclic value', then.theReturnedTableShouldHaveAHeadWithTheCyclicObjectValues);
+		});
+	});
 	Given('an array of objects with the same keys', given.anArrayOfObjectsWithTheSameKeys, () => {
 		When('the array is tablified', when.theArrayIsTablified, () => {
 			Then('the returned table should have a head with the objects’ keys', then.theReturnedTableShouldHaveAHeadWithTheObjectsKeys);

--- a/test/specs/utils/tablify.js
+++ b/test/specs/utils/tablify.js
@@ -45,7 +45,7 @@ describe('tablify util', () => {
 	Given('a cyclic object', given.aCyclicObject, () => {
 		When('the object is tablified', when.theObjectIsTablified, () => {
 			Then('the returned table should have a head with the cyclic object’s keys', then.theReturnedTableShouldHaveAHeadWithTheCyclicObjectKeys);
-			Then('the returned table should have a row with the cyclic object’s values and show error when cyclic value', then.theReturnedTableShouldHaveAHeadWithTheCyclicObjectValues);
+			Then('the returned table should have a row with the cyclic object’s values including an error for the cyclic value', then.theReturnedTableShouldHaveARowWithTheCuclicObjectValuesIncludingAnErrorForTheCyclicValue);
 		});
 	});
 	Given('an array of objects with the same keys', given.anArrayOfObjectsWithTheSameKeys, () => {

--- a/test/steps/api/1_given.js
+++ b/test/steps/api/1_given.js
@@ -17,4 +17,5 @@ import liskAPIInstance from '../../../src/utils/api';
 
 export function aLiskAPIInstance() {
 	this.test.ctx.liskAPIInstance = liskAPIInstance;
+	sandbox.stub(this.test.ctx.liskAPIInstance, 'sendRequest');
 }

--- a/test/steps/api/2_when.js
+++ b/test/steps/api/2_when.js
@@ -13,13 +13,12 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import liskAPIInstance from '../../../src/utils/api';
 
-export function sendRequestSuccesses() {
-	sandbox.stub(liskAPIInstance, 'sendRequest').resolves({ success: true });
+export function theRequestIsSuccessful() {
+	this.test.ctx.liskAPIInstance.sendRequest.resolves({ success: true });
 }
 
-export function sendRequestFails() {
-	sandbox.stub(liskAPIInstance, 'sendRequest').resolves({ success: false, message: 'request failed' });
+export function theRequestFails() {
+	this.test.ctx.liskAPIInstance.sendRequest.resolves({ success: false, message: 'request failed' });
 }
 

--- a/test/steps/api/2_when.js
+++ b/test/steps/api/2_when.js
@@ -13,14 +13,13 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-export * from './api/2_when';
-export * from './config/2_when';
-export * from './crypto/2_when';
-export * from './domain/2_when';
-export * from './files/2_when';
-export * from './general/2_when';
-export * from './inputs/2_when';
-export * from './mnemonic/2_when';
-export * from './printing/2_when';
-export * from './queries/2_when';
-export * from './vorpal/2_when';
+import liskAPIInstance from '../../../src/utils/api';
+
+export function sendRequestSuccesses() {
+	sandbox.stub(liskAPIInstance, 'sendRequest').resolves({ success: true });
+}
+
+export function sendRequestFails() {
+	sandbox.stub(liskAPIInstance, 'sendRequest').resolves({ success: false, message: 'request failed' });
+}
+

--- a/test/steps/general/1_given.js
+++ b/test/steps/general/1_given.js
@@ -56,6 +56,7 @@ export function aDeeplyNestedObject() {
 				keys: {
 					more: ['publicKey1', 'publicKey2'],
 				},
+				array: ['secretKey1', 'secretKey2'],
 			},
 		},
 	};

--- a/test/steps/general/1_given.js
+++ b/test/steps/general/1_given.js
@@ -62,6 +62,19 @@ export function aDeeplyNestedObject() {
 	};
 }
 
+export function aCyclicObject() {
+	const obj = {
+		root: 'value',
+		nested: {
+			object: 'values',
+			testing: 123,
+			nullValue: null,
+		},
+	};
+	obj.circular = obj;
+	this.test.ctx.testObject = obj;
+}
+
 export function aNestedObject() {
 	this.test.ctx.testObject = {
 		root: 'value',

--- a/test/steps/printing/3_then.js
+++ b/test/steps/printing/3_then.js
@@ -145,6 +145,12 @@ export function theReturnedTableShouldHaveAHeadWithTheObjectDeeplyNestedKeys() {
 	return (returnValue.options).should.have.property('head').eql(keys);
 }
 
+export function theReturnedTableShouldHaveAHeadWithTheCyclicObjectKeys() {
+	const { returnValue } = this.test.ctx;
+	const keys = ['root', 'nested.object', 'nested.testing', 'nested.nullValue', 'circular.root', 'circular.nested.object', 'circular.nested.testing', 'circular.nested.nullValue', 'circular.circular.root', 'circular.circular.nested', 'circular.circular.circular'];
+	return (returnValue.options).should.have.property('head').eql(keys);
+}
+
 export function theReturnedTableShouldHaveAHeadWithTheObjectNestedValues() {
 	const { returnValue } = this.test.ctx;
 	const values = ['value', 'values', 123, null];
@@ -154,6 +160,12 @@ export function theReturnedTableShouldHaveAHeadWithTheObjectNestedValues() {
 export function theReturnedTableShouldHaveAHeadWithTheObjectDeeplyNestedValues() {
 	const { returnValue } = this.test.ctx;
 	const values = ['value', 'values', 123, null, 'aPublicKeyString', '{"more":["publicKey1","publicKey2"]}', 'secretKey1\nsecretKey2'];
+	return (returnValue[0]).should.eql(values);
+}
+
+export function theReturnedTableShouldHaveAHeadWithTheCyclicObjectValues() {
+	const { returnValue } = this.test.ctx;
+	const values = ['value', 'values', 123, null, 'value', 'values', 123, null, 'value', '{"object":"values","testing":123,"nullValue":null}', 'Error: cyclic object cannot be displayed.'];
 	return (returnValue[0]).should.eql(values);
 }
 

--- a/test/steps/printing/3_then.js
+++ b/test/steps/printing/3_then.js
@@ -163,7 +163,7 @@ export function theReturnedTableShouldHaveAHeadWithTheObjectDeeplyNestedValues()
 	return (returnValue[0]).should.eql(values);
 }
 
-export function theReturnedTableShouldHaveAHeadWithTheCyclicObjectValues() {
+export function theReturnedTableShouldHaveARowWithTheCuclicObjectValuesIncludingAnErrorForTheCyclicValue() {
 	const { returnValue } = this.test.ctx;
 	const values = ['value', 'values', 123, null, 'value', 'values', 123, null, 'value', '{"object":"values","testing":123,"nullValue":null}', 'Error: cyclic object cannot be displayed.'];
 	return (returnValue[0]).should.eql(values);

--- a/test/steps/printing/3_then.js
+++ b/test/steps/printing/3_then.js
@@ -141,7 +141,7 @@ export function theReturnedTableShouldHaveAHeadWithTheObjectNestedKeys() {
 
 export function theReturnedTableShouldHaveAHeadWithTheObjectDeeplyNestedKeys() {
 	const { returnValue } = this.test.ctx;
-	const keys = ['root', 'nested.object', 'nested.testing', 'nested.nullValue', 'nested.asset.publicKey', 'nested.asset.keys.more'];
+	const keys = ['root', 'nested.object', 'nested.testing', 'nested.nullValue', 'nested.asset.publicKey', 'nested.asset.keys', 'nested.asset.array'];
 	return (returnValue.options).should.have.property('head').eql(keys);
 }
 
@@ -153,7 +153,7 @@ export function theReturnedTableShouldHaveAHeadWithTheObjectNestedValues() {
 
 export function theReturnedTableShouldHaveAHeadWithTheObjectDeeplyNestedValues() {
 	const { returnValue } = this.test.ctx;
-	const values = ['value', 'values', 123, null, 'aPublicKeyString', 'publicKey1\npublicKey2'];
+	const values = ['value', 'values', 123, null, 'aPublicKeyString', '{"more":["publicKey1","publicKey2"]}', 'secretKey1\nsecretKey2'];
 	return (returnValue[0]).should.eql(values);
 }
 

--- a/test/steps/queries/1_given.js
+++ b/test/steps/queries/1_given.js
@@ -44,7 +44,7 @@ export function aQueryInstanceHasBeenInitialised() {
 	queryInstance.getTransaction.resolves({ transaction: queryResult });
 
 	this.test.ctx.queryResult = queryResult;
-	this.test.ctx.qtheQueryInstanceGetsABlockUsingTheIDueryInstance = queryInstance;
+	this.test.ctx.queryInstance = queryInstance;
 }
 
 export function aQueryInstance() {

--- a/test/steps/queries/1_given.js
+++ b/test/steps/queries/1_given.js
@@ -13,7 +13,6 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import liskAPIInstance from '../../../src/utils/api';
 import queryInstance from '../../../src/utils/query';
 import {
 	getFirstQuotedString,
@@ -45,10 +44,9 @@ export function aQueryInstanceHasBeenInitialised() {
 	queryInstance.getTransaction.resolves({ transaction: queryResult });
 
 	this.test.ctx.queryResult = queryResult;
-	this.test.ctx.queryInstance = queryInstance;
+	this.test.ctx.qtheQueryInstanceGetsABlockUsingTheIDueryInstance = queryInstance;
 }
 
 export function aQueryInstance() {
 	this.test.ctx.queryInstance = queryInstance;
-	sandbox.stub(liskAPIInstance, 'sendRequest');
 }


### PR DESCRIPTION
Closes #452 

### What was the problem?
- Deeply nested response object
- Recursive without limit exceeds the limit of call stack

### How did I fix it?
- Add limit to recursive feature
- Handle failed API call

### How to test it?
Run `get block 2606559219099047919` or any `get` command without running lisk-core

### Review checklist
* The PR solves #452

