### PR TITLE
Fix recursive to have limit and catch failed API - Closes #452

### DIFF
--- a/src/utils/error.js
+++ b/src/utils/error.js
@@ -30,3 +30,11 @@ export class ValidationError extends Error {
 		this.name = 'ValidationError';
 	}
 }
+
+export class PrintError extends Error {
+	constructor(message) {
+		super(message);
+		this.message = chalk.red(message);
+		this.name = 'PrintError';
+	}
+}

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -44,6 +44,7 @@ class Query {
 
 		const handleSuccess = async result => {
 			if (overrideTestnetSetting) this.resetTestnetSetting();
+			if (!result.success) throw new Error(result.message);
 			return result;
 		};
 		const handleFailure = async result => {

--- a/src/utils/tablify.js
+++ b/src/utils/tablify.js
@@ -58,7 +58,7 @@ const reduceKeys = (keys, row) => {
 const getKeys = (data, limit = 3, loop = 1) => {
 	if (loop > limit) {
 		throw new PrintError(
-			'Maximum nesting of the object is exceeded to be displayed as a table.',
+			`Output cannot be displayed in table format: Maximum object depth of ${limit} was exceeded. Consider using JSON output format.`,
 		);
 	}
 	return Object.entries(data)

--- a/test/specs/utils/error.js
+++ b/test/specs/utils/error.js
@@ -66,4 +66,24 @@ describe('Custom Errors', () => {
 			);
 		},
 	);
+	Given(
+		'a function that throws a print error "cannot be displayed"',
+		given.aFunctionThatThrowsAPrintError,
+		() => {
+			When('the print error is thrown', when.thePrintErrorIsThrown, () => {
+				Then(
+					'it should print the error message in red',
+					then.itShouldPrintTheErrorMessageInRed,
+				);
+				Then(
+					'the error should have the name "PrintError"',
+					then.theErrorShouldHaveTheName,
+				);
+				Then(
+					'the error should be an instance of Node’s built-in Error',
+					then.theErrorShouldBeInstanceOfNodesBuiltInError,
+				);
+			});
+		},
+	);
 });

--- a/test/specs/utils/error.js
+++ b/test/specs/utils/error.js
@@ -36,7 +36,7 @@ describe('Custom Errors', () => {
 					);
 					Then(
 						'the error should be an instance of Node’s built-in Error',
-						then.theErrorShouldBeInstanceOfNodesBuiltInError,
+						then.theErrorShouldBeAnInstanceOfNodesBuiltInError,
 					);
 				},
 			);
@@ -60,7 +60,7 @@ describe('Custom Errors', () => {
 					);
 					Then(
 						'the error should be an instance of Node’s built-in Error',
-						then.theErrorShouldBeInstanceOfNodesBuiltInError,
+						then.theErrorShouldBeAnInstanceOfNodesBuiltInError,
 					);
 				},
 			);
@@ -81,7 +81,7 @@ describe('Custom Errors', () => {
 				);
 				Then(
 					'the error should be an instance of Node’s built-in Error',
-					then.theErrorShouldBeInstanceOfNodesBuiltInError,
+					then.theErrorShouldBeAnInstanceOfNodesBuiltInError,
 				);
 			});
 		},

--- a/test/specs/utils/query.js
+++ b/test/specs/utils/query.js
@@ -41,6 +41,26 @@ describe('Query class', () => {
 				then.theQueryInstanceShouldHaveAHandlerFor,
 			);
 			describe('#sendRequest', () => {
+				When(
+					'the query instance sends a request and the lisk API instance returns the success response',
+					when.theQueryInstanceSendsARequestAndTheLiskAPIInstanceReturnsTheSuccessResponse,
+					() => {
+						Then(
+							'it should resolve to the result of sending the request',
+							then.itShouldResolveToTheResultOfSendingTheRequest,
+						);
+					},
+				);
+				When(
+					'the query instance sends a request and the lisk API instance returns the fail response',
+					when.theQueryInstanceSendsARequestAndTheLiskAPIInstanceReturnsTheFailResponse,
+					() => {
+						Then(
+							'it should reject with the error message',
+							then.itShouldRejectWithTheErrorMessage,
+						);
+					},
+				);
 				Given('an endpoint "delegates/get"', given.anEndpoint, () => {
 					Given('a parameters object', given.aParametersObject, () => {
 						Given(

--- a/test/specs/utils/query.js
+++ b/test/specs/utils/query.js
@@ -13,11 +13,13 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import { setUpLiskJSAPIInstance } from '../../steps/setup';
 import * as given from '../../steps/1_given';
 import * as when from '../../steps/2_when';
 import * as then from '../../steps/3_then';
 
 describe('Query class', () => {
+	beforeEach(setUpLiskJSAPIInstance);
 	Given('a Lisk API instance', given.aLiskAPIInstance, () => {
 		Given('a query instance', given.aQueryInstance, () => {
 			Then(
@@ -42,8 +44,8 @@ describe('Query class', () => {
 			);
 			describe('#sendRequest', () => {
 				When(
-					'the query instance sends a request and the lisk API instance returns the success response',
-					when.theQueryInstanceSendsARequestAndTheLiskAPIInstanceReturnsTheSuccessResponse,
+					'the query instance sends a request and the lisk API instance resolves with a successful response',
+					when.theQueryInstanceSendsARequestAndTheLiskAPIInstanceResolvesWithASuccessfulResponse,
 					() => {
 						Then(
 							'it should resolve to the result of sending the request',
@@ -52,8 +54,8 @@ describe('Query class', () => {
 					},
 				);
 				When(
-					'the query instance sends a request and the lisk API instance returns the fail response',
-					when.theQueryInstanceSendsARequestAndTheLiskAPIInstanceReturnsTheFailResponse,
+					'the query instance sends a request and the lisk API instance resolves with a failed response',
+					when.theQueryInstanceSendsARequestAndTheLiskAPIInstanceResolvesWithAFailedResponse,
 					() => {
 						Then(
 							'it should reject with the error message',

--- a/test/specs/utils/query.js
+++ b/test/specs/utils/query.js
@@ -13,13 +13,13 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { setUpLiskJSAPIInstance } from '../../steps/setup';
+import { setUpUtilQuery } from '../../steps/setup';
 import * as given from '../../steps/1_given';
 import * as when from '../../steps/2_when';
 import * as then from '../../steps/3_then';
 
 describe('Query class', () => {
-	beforeEach(setUpLiskJSAPIInstance);
+	beforeEach(setUpUtilQuery);
 	Given('a Lisk API instance', given.aLiskAPIInstance, () => {
 		Given('a query instance', given.aQueryInstance, () => {
 			Then(

--- a/test/specs/utils/tablify.js
+++ b/test/specs/utils/tablify.js
@@ -73,8 +73,8 @@ describe('tablify util', () => {
 				then.theReturnedTableShouldHaveAHeadWithTheCyclicObjectKeys,
 			);
 			Then(
-				'the returned table should have a row with the cyclic object’s values including an error for the cyclic value',
-				then.theReturnedTableShouldHaveARowWithTheCyclicObjectValuesIncludingAnErrorForTheCyclicValue,
+				'the returned table should have a row with the cyclic object’s values including a message for the cyclic value',
+				then.theReturnedTableShouldHaveARowWithTheCyclicObjectValuesIncludingAMessageForTheCyclicValue,
 			);
 		});
 	});

--- a/test/specs/utils/tablify.js
+++ b/test/specs/utils/tablify.js
@@ -57,24 +57,16 @@ describe('tablify util', () => {
 	Given('a deeply nested object', given.aDeeplyNestedObject, () => {
 		When('the object is tablified', when.theObjectIsTablified, () => {
 			Then(
-				'the returned table should have a head with the object’s deeply nested keys',
-				then.theReturnedTableShouldHaveAHeadWithTheObjectDeeplyNestedKeys,
-			);
-			Then(
-				'the returned table should have a row with the object’s deeply nested values',
-				then.theReturnedTableShouldHaveAHeadWithTheObjectDeeplyNestedValues,
+				'it should throw a print error "Maximum nesting of the object is exceeded to be displayed as a table."',
+				then.itShouldThrowPrintError,
 			);
 		});
 	});
 	Given('a cyclic object', given.aCyclicObject, () => {
 		When('the object is tablified', when.theObjectIsTablified, () => {
 			Then(
-				'the returned table should have a head with the cyclic object’s keys',
-				then.theReturnedTableShouldHaveAHeadWithTheCyclicObjectKeys,
-			);
-			Then(
-				'the returned table should have a row with the cyclic object’s values including a message for the cyclic value',
-				then.theReturnedTableShouldHaveARowWithTheCyclicObjectValuesIncludingAMessageForTheCyclicValue,
+				'it should throw a print error "Maximum nesting of the object is exceeded to be displayed as a table."',
+				then.itShouldThrowPrintError,
 			);
 		});
 	});

--- a/test/specs/utils/tablify.js
+++ b/test/specs/utils/tablify.js
@@ -66,6 +66,18 @@ describe('tablify util', () => {
 			);
 		});
 	});
+	Given('a cyclic object', given.aCyclicObject, () => {
+		When('the object is tablified', when.theObjectIsTablified, () => {
+			Then(
+				'the returned table should have a head with the cyclic object’s keys',
+				then.theReturnedTableShouldHaveAHeadWithTheCyclicObjectKeys,
+			);
+			Then(
+				'the returned table should have a row with the cyclic object’s values including an error for the cyclic value',
+				then.theReturnedTableShouldHaveARowWithTheCyclicObjectValuesIncludingAnErrorForTheCyclicValue,
+			);
+		});
+	});
 	Given(
 		'an array of objects with the same keys',
 		given.anArrayOfObjectsWithTheSameKeys,

--- a/test/specs/utils/tablify.js
+++ b/test/specs/utils/tablify.js
@@ -57,7 +57,7 @@ describe('tablify util', () => {
 	Given('a deeply nested object', given.aDeeplyNestedObject, () => {
 		When('the object is tablified', when.theObjectIsTablified, () => {
 			Then(
-				'it should throw a print error "Maximum nesting of the object is exceeded to be displayed as a table."',
+				'it should throw print error "Output cannot be displayed in table format: Maximum object depth of 3 was exceeded. Consider using JSON output format."',
 				then.itShouldThrowPrintError,
 			);
 		});
@@ -65,7 +65,7 @@ describe('tablify util', () => {
 	Given('a cyclic object', given.aCyclicObject, () => {
 		When('the object is tablified', when.theObjectIsTablified, () => {
 			Then(
-				'it should throw a print error "Maximum nesting of the object is exceeded to be displayed as a table."',
+				'it should throw print error "Output cannot be displayed in table format: Maximum object depth of 3 was exceeded. Consider using JSON output format."',
 				then.itShouldThrowPrintError,
 			);
 		});

--- a/test/steps/api/1_given.js
+++ b/test/steps/api/1_given.js
@@ -16,11 +16,5 @@
 import liskAPIInstance from '../../../src/utils/api';
 
 export function aLiskAPIInstance() {
-	const sendRequestDefaultResult = { success: true };
-	sandbox
-		.stub(liskAPIInstance, 'sendRequest')
-		.resolves(sendRequestDefaultResult);
-	sandbox.stub(liskAPIInstance, 'setTestnet');
 	this.test.ctx.liskAPIInstance = liskAPIInstance;
-	this.test.ctx.sendRequestResult = sendRequestDefaultResult;
 }

--- a/test/steps/api/1_given.js
+++ b/test/steps/api/1_given.js
@@ -16,5 +16,11 @@
 import liskAPIInstance from '../../../src/utils/api';
 
 export function aLiskAPIInstance() {
+	const sendRequestDefaultResult = { success: true };
+	sandbox
+		.stub(liskAPIInstance, 'sendRequest')
+		.resolves(sendRequestDefaultResult);
+	sandbox.stub(liskAPIInstance, 'setTestnet');
 	this.test.ctx.liskAPIInstance = liskAPIInstance;
+	this.test.ctx.sendRequestResult = sendRequestDefaultResult;
 }

--- a/test/steps/general/1_given.js
+++ b/test/steps/general/1_given.js
@@ -66,12 +66,23 @@ export function aDeeplyNestedObject() {
 			nullValue: null,
 			asset: {
 				publicKey: 'aPublicKeyString',
-				keys: {
-					more: ['publicKey1', 'publicKey2'],
-				},
+				keys: ['publicKey1', 'publicKey2'],
 			},
 		},
 	};
+}
+
+export function aCyclicObject() {
+	const obj = {
+		root: 'value',
+		nested: {
+			object: 'values',
+			testing: 123,
+			nullValue: null,
+		},
+	};
+	obj.circular = obj;
+	this.test.ctx.testObject = obj;
 }
 
 export function aNestedObject() {

--- a/test/steps/general/1_given.js
+++ b/test/steps/general/1_given.js
@@ -14,7 +14,11 @@
  *
  */
 import { getFirstQuotedString, getQuotedStrings } from '../utils';
-import { FileSystemError, ValidationError } from '../../../src/utils/error';
+import {
+	FileSystemError,
+	ValidationError,
+	PrintError,
+} from '../../../src/utils/error';
 
 export function stringArguments() {
 	this.test.ctx.testArguments = getQuotedStrings(this.test.parent.title);
@@ -38,6 +42,16 @@ export function aFunctionThatThrowsAValidationError() {
 
 	this.test.ctx.errorMessage = errorMessage;
 	this.test.ctx.validationErrorFn = validationErrorFn;
+}
+
+export function aFunctionThatThrowsAPrintError() {
+	const errorMessage = getFirstQuotedString(this.test.parent.title);
+	const printErrorFn = () => {
+		throw new PrintError(errorMessage);
+	};
+
+	this.test.ctx.errorMessage = errorMessage;
+	this.test.ctx.printErrorFn = printErrorFn;
 }
 
 export function anErrorObject() {
@@ -66,7 +80,9 @@ export function aDeeplyNestedObject() {
 			nullValue: null,
 			asset: {
 				publicKey: 'aPublicKeyString',
-				keys: ['publicKey1', 'publicKey2'],
+				keys: {
+					more: ['publicKey1', 'publicKey2'],
+				},
 			},
 		},
 	};
@@ -92,6 +108,9 @@ export function aNestedObject() {
 			object: 'values',
 			testing: 123,
 			nullValue: null,
+			keys: {
+				more: ['publicKey1', 'publicKey2'],
+			},
 		},
 	};
 }

--- a/test/steps/general/2_when.js
+++ b/test/steps/general/2_when.js
@@ -57,3 +57,19 @@ export function theValidationErrorIsThrown() {
 		return testFunction;
 	}
 }
+
+export function thePrintErrorIsThrown() {
+	const { printErrorFn } = this.test.ctx;
+	try {
+		const returnValue = printErrorFn();
+		// istanbul ignore next
+		this.test.ctx.returnValue = returnValue;
+		// istanbul ignore next
+		return returnValue;
+	} catch (error) {
+		const testFunction = printErrorFn.bind(null);
+		this.test.ctx.testFunction = testFunction;
+		this.test.ctx.testError = error;
+		return testFunction;
+	}
+}

--- a/test/steps/general/3_then.js
+++ b/test/steps/general/3_then.js
@@ -14,7 +14,11 @@
  *
  */
 import { getFirstQuotedString, getFirstNumber } from '../utils';
-import { ValidationError, FileSystemError } from '../../../src/utils/error';
+import {
+	ValidationError,
+	FileSystemError,
+	PrintError,
+} from '../../../src/utils/error';
 
 export function theErrorShouldBeInstanceOfNodesBuiltInError() {
 	const { testError } = this.test.ctx;
@@ -46,6 +50,14 @@ export function itShouldThrowFileSystemError() {
 	return expect(testFunction)
 		.to.throw()
 		.and.be.customError(new FileSystemError(message));
+}
+
+export function itShouldThrowPrintError() {
+	const { testFunction } = this.test.ctx;
+	const message = getFirstQuotedString(this.test.title);
+	return expect(testFunction)
+		.to.throw()
+		.and.be.customError(new PrintError(message));
 }
 
 export function itShouldExitWithCode() {

--- a/test/steps/general/3_then.js
+++ b/test/steps/general/3_then.js
@@ -20,7 +20,7 @@ import {
 	PrintError,
 } from '../../../src/utils/error';
 
-export function theErrorShouldBeInstanceOfNodesBuiltInError() {
+export function theErrorShouldBeAnInstanceOfNodesBuiltInError() {
 	const { testError } = this.test.ctx;
 	return expect(testError).to.be.instanceOf(Error);
 }

--- a/test/steps/printing/2_when.js
+++ b/test/steps/printing/2_when.js
@@ -55,12 +55,28 @@ export function theResultIsPrintedUsingTheActiveCommandContext() {
 
 export function theObjectIsTablified() {
 	const { testObject } = this.test.ctx;
-	this.test.ctx.returnValue = tablify(testObject);
+	try {
+		const returnValue = tablify(testObject);
+		this.test.ctx.returnValue = returnValue;
+		return returnValue;
+	} catch (error) {
+		const testFunction = tablify.bind(null, testObject);
+		this.test.ctx.testFunction = testFunction;
+		return testFunction;
+	}
 }
 
 export function theArrayIsTablified() {
 	const { testArray } = this.test.ctx;
-	this.test.ctx.returnValue = tablify(testArray);
+	try {
+		const returnValue = tablify(testArray);
+		this.test.ctx.returnValue = returnValue;
+		return returnValue;
+	} catch (error) {
+		const testFunction = tablify.bind(null, testArray);
+		this.test.ctx.testFunction = testFunction;
+		return testFunction;
+	}
 }
 
 export function shouldUseJSONOutputIsCalledWithTheConfigAndOptions() {

--- a/test/steps/printing/3_then.js
+++ b/test/steps/printing/3_then.js
@@ -138,41 +138,12 @@ export function theReturnedTableShouldHaveARowWithTheObjectValues() {
 
 export function theReturnedTableShouldHaveAHeadWithTheObjectNestedKeys() {
 	const { returnValue } = this.test.ctx;
-	const keys = ['root', 'nested.object', 'nested.testing', 'nested.nullValue'];
-	return expect(returnValue.options)
-		.to.have.property('head')
-		.eql(keys);
-}
-
-export function theReturnedTableShouldHaveAHeadWithTheObjectDeeplyNestedKeys() {
-	const { returnValue } = this.test.ctx;
 	const keys = [
 		'root',
 		'nested.object',
 		'nested.testing',
 		'nested.nullValue',
-		'nested.asset.publicKey',
-		'nested.asset.keys',
-	];
-	return expect(returnValue.options)
-		.to.have.property('head')
-		.eql(keys);
-}
-
-export function theReturnedTableShouldHaveAHeadWithTheCyclicObjectKeys() {
-	const { returnValue } = this.test.ctx;
-	const keys = [
-		'root',
-		'nested.object',
-		'nested.testing',
-		'nested.nullValue',
-		'circular.root',
-		'circular.nested.object',
-		'circular.nested.testing',
-		'circular.nested.nullValue',
-		'circular.circular.root',
-		'circular.circular.nested',
-		'circular.circular.circular',
+		'nested.keys.more',
 	];
 	return expect(returnValue.options)
 		.to.have.property('head')
@@ -181,38 +152,7 @@ export function theReturnedTableShouldHaveAHeadWithTheCyclicObjectKeys() {
 
 export function theReturnedTableShouldHaveAHeadWithTheObjectNestedValues() {
 	const { returnValue } = this.test.ctx;
-	const values = ['value', 'values', 123, null];
-	return expect(returnValue[0]).to.eql(values);
-}
-
-export function theReturnedTableShouldHaveAHeadWithTheObjectDeeplyNestedValues() {
-	const { returnValue } = this.test.ctx;
-	const values = [
-		'value',
-		'values',
-		123,
-		null,
-		'aPublicKeyString',
-		'publicKey1\npublicKey2',
-	];
-	return expect(returnValue[0]).to.eql(values);
-}
-
-export function theReturnedTableShouldHaveARowWithTheCyclicObjectValuesIncludingAMessageForTheCyclicValue() {
-	const { returnValue } = this.test.ctx;
-	const values = [
-		'value',
-		'values',
-		123,
-		null,
-		'value',
-		'values',
-		123,
-		null,
-		'value',
-		'{"object":"values","testing":123,"nullValue":null}',
-		'Cyclic object cannot be displayed.',
-	];
+	const values = ['value', 'values', 123, null, 'publicKey1\npublicKey2'];
 	return expect(returnValue[0]).to.eql(values);
 }
 

--- a/test/steps/printing/3_then.js
+++ b/test/steps/printing/3_then.js
@@ -152,7 +152,27 @@ export function theReturnedTableShouldHaveAHeadWithTheObjectDeeplyNestedKeys() {
 		'nested.testing',
 		'nested.nullValue',
 		'nested.asset.publicKey',
-		'nested.asset.keys.more',
+		'nested.asset.keys',
+	];
+	return expect(returnValue.options)
+		.to.have.property('head')
+		.eql(keys);
+}
+
+export function theReturnedTableShouldHaveAHeadWithTheCyclicObjectKeys() {
+	const { returnValue } = this.test.ctx;
+	const keys = [
+		'root',
+		'nested.object',
+		'nested.testing',
+		'nested.nullValue',
+		'circular.root',
+		'circular.nested.object',
+		'circular.nested.testing',
+		'circular.nested.nullValue',
+		'circular.circular.root',
+		'circular.circular.nested',
+		'circular.circular.circular',
 	];
 	return expect(returnValue.options)
 		.to.have.property('head')
@@ -174,6 +194,24 @@ export function theReturnedTableShouldHaveAHeadWithTheObjectDeeplyNestedValues()
 		null,
 		'aPublicKeyString',
 		'publicKey1\npublicKey2',
+	];
+	return expect(returnValue[0]).to.eql(values);
+}
+
+export function theReturnedTableShouldHaveARowWithTheCyclicObjectValuesIncludingAnErrorForTheCyclicValue() {
+	const { returnValue } = this.test.ctx;
+	const values = [
+		'value',
+		'values',
+		123,
+		null,
+		'value',
+		'values',
+		123,
+		null,
+		'value',
+		'{"object":"values","testing":123,"nullValue":null}',
+		'Cyclic object cannot be displayed.',
 	];
 	return expect(returnValue[0]).to.eql(values);
 }

--- a/test/steps/printing/3_then.js
+++ b/test/steps/printing/3_then.js
@@ -198,7 +198,7 @@ export function theReturnedTableShouldHaveAHeadWithTheObjectDeeplyNestedValues()
 	return expect(returnValue[0]).to.eql(values);
 }
 
-export function theReturnedTableShouldHaveARowWithTheCyclicObjectValuesIncludingAnErrorForTheCyclicValue() {
+export function theReturnedTableShouldHaveARowWithTheCyclicObjectValuesIncludingAMessageForTheCyclicValue() {
 	const { returnValue } = this.test.ctx;
 	const values = [
 		'value',

--- a/test/steps/queries/1_given.js
+++ b/test/steps/queries/1_given.js
@@ -13,7 +13,6 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import liskAPIInstance from '../../../src/utils/api';
 import queryInstance from '../../../src/utils/query';
 import { getFirstQuotedString, getQuotedStrings } from '../utils';
 
@@ -61,13 +60,5 @@ export function aQueryInstanceHasBeenInitialised() {
 }
 
 export function aQueryInstance() {
-	const sendRequestResult = {
-		someKey: 'some value',
-	};
-
-	sandbox.stub(liskAPIInstance, 'sendRequest').resolves(sendRequestResult);
-	sandbox.stub(liskAPIInstance, 'setTestnet');
-
 	this.test.ctx.queryInstance = queryInstance;
-	this.test.ctx.sendRequestResult = sendRequestResult;
 }

--- a/test/steps/queries/2_when.js
+++ b/test/steps/queries/2_when.js
@@ -15,6 +15,29 @@
  */
 import { processQueryResult } from '../../../src/utils/helpers';
 
+export function theQueryInstanceSendsARequestAndTheLiskAPIInstanceReturnsTheSuccessResponse() {
+	const { liskAPIInstance, queryInstance } = this.test.ctx;
+	const sendRequestResult = { success: true };
+	liskAPIInstance.sendRequest.resolves(sendRequestResult);
+	this.test.ctx.sendRequestResult = sendRequestResult;
+	const returnValue = queryInstance.sendRequest('', {});
+	this.test.ctx.returnValue = returnValue;
+	return returnValue.catch(e => e);
+}
+
+export function theQueryInstanceSendsARequestAndTheLiskAPIInstanceReturnsTheFailResponse() {
+	const { liskAPIInstance, queryInstance } = this.test.ctx;
+	const sendRequestResult = {
+		success: false,
+		message: 'request failed',
+	};
+	liskAPIInstance.sendRequest.resolves(sendRequestResult);
+	const returnValue = queryInstance.sendRequest('', {});
+	this.test.ctx.returnValue = returnValue;
+	this.test.ctx.errorMessage = sendRequestResult.message;
+	return returnValue.catch(e => e);
+}
+
 export function theQueryInstanceSendsARequestUsingTheEndpointAndTheParameters() {
 	const { queryInstance, endpoint, parameters } = this.test.ctx;
 	const returnValue = queryInstance.sendRequest(endpoint, parameters);

--- a/test/steps/queries/2_when.js
+++ b/test/steps/queries/2_when.js
@@ -15,26 +15,32 @@
  */
 import { processQueryResult } from '../../../src/utils/helpers';
 
-export function theQueryInstanceSendsARequestAndTheLiskAPIInstanceReturnsTheSuccessResponse() {
+export function theQueryInstanceSendsARequestAndTheLiskAPIInstanceResolvesWithASuccessfulResponse() {
 	const { liskAPIInstance, queryInstance } = this.test.ctx;
+
 	const sendRequestResult = { success: true };
 	liskAPIInstance.sendRequest.resolves(sendRequestResult);
 	this.test.ctx.sendRequestResult = sendRequestResult;
+
 	const returnValue = queryInstance.sendRequest('', {});
 	this.test.ctx.returnValue = returnValue;
+
 	return returnValue.catch(e => e);
 }
 
-export function theQueryInstanceSendsARequestAndTheLiskAPIInstanceReturnsTheFailResponse() {
+export function theQueryInstanceSendsARequestAndTheLiskAPIInstanceResolvesWithAFailedResponse() {
 	const { liskAPIInstance, queryInstance } = this.test.ctx;
+
 	const sendRequestResult = {
 		success: false,
 		message: 'request failed',
 	};
 	liskAPIInstance.sendRequest.resolves(sendRequestResult);
+	this.test.ctx.errorMessage = sendRequestResult.message;
+
 	const returnValue = queryInstance.sendRequest('', {});
 	this.test.ctx.returnValue = returnValue;
-	this.test.ctx.errorMessage = sendRequestResult.message;
+
 	return returnValue.catch(e => e);
 }
 

--- a/test/steps/setup.js
+++ b/test/steps/setup.js
@@ -192,9 +192,6 @@ const restoreEnvVariable = variable =>
 			delete process.env[variable];
 		}
 	};
-export function setUpLiskJSAPIInstance() {
-	setUpLiskJSAPIStubs.call(this);
-}
 
 export function setUpCommandBroadcastSignature() {
 	setUpLiskJSAPIStubs.call(this);
@@ -325,6 +322,10 @@ export function setUpUtilInputUtils() {
 
 export function tearDownUtilInputUtils() {
 	restoreEnvVariable(TEST_PASSPHRASE).call(this);
+}
+
+export function setUpUtilQuery() {
+	setUpLiskJSAPIStubs.call(this);
 }
 
 export function setUpUtilPrint() {

--- a/test/steps/setup.js
+++ b/test/steps/setup.js
@@ -79,15 +79,21 @@ const setUpReadlineStubs = () => {
 };
 
 function setUpLiskJSAPIStubs() {
+	const sendRequestDefaultResult = { success: true };
 	const broadcastTransactionResponse = {
 		message: 'Transaction accepted by the node for processing',
 	};
 	const broadcastSignaturesResponse = {
 		message: 'Signature is accepted by the node for processing',
 	};
+	this.test.ctx.sendRequestResult = sendRequestDefaultResult;
 	this.test.ctx.broadcastTransactionResponse = broadcastTransactionResponse;
 	this.test.ctx.broadcastSignaturesResponse = broadcastSignaturesResponse;
 
+	sandbox
+		.stub(liskAPIInstance, 'sendRequest')
+		.resolves(sendRequestDefaultResult);
+	sandbox.stub(liskAPIInstance, 'setTestnet');
 	sandbox
 		.stub(liskAPIInstance, 'broadcastTransaction')
 		.returns(broadcastTransactionResponse);
@@ -186,6 +192,9 @@ const restoreEnvVariable = variable =>
 			delete process.env[variable];
 		}
 	};
+export function setUpLiskJSAPIInstance() {
+	setUpLiskJSAPIStubs.call(this);
+}
 
 export function setUpCommandBroadcastSignature() {
 	setUpLiskJSAPIStubs.call(this);


### PR DESCRIPTION
Closes #452 

Ported from #457 

### What was the problem?
- Deeply nested response object
- Recursive without limit exceeds the limit of call stack

### How did I fix it?
- Add limit to recursive feature
- Handle failed API call

### How to test it?
Run `get block 2606559219099047919` or any `get` command without running lisk-core

### Review checklist
* The PR solves #452

