### PR TITLE
Fix register multisignature appending plus - Closes #470

### DIFF
--- a/src/commands/create_transaction_cast_votes.js
+++ b/src/commands/create_transaction_cast_votes.js
@@ -27,8 +27,8 @@ const description = `Creates a transaction which will cast votes (or unvotes) fo
 	- create transaction 3 --votes 215b667a32a5cd51a94c9c2046c11fffb08c65748febec099451e3b164452bca,922fbfdd596fa78269bbcadc67ec2a1cc15fc929a19c462169568d7a3df1a1aa --unvotes e01b6b8a9b808ec3f67a638a2d3fa0fe1a9439b91dbdde92e2839c3327bd4589,ac09bc40c889f688f9158cca1fcfcdf6320f501242e0f7088d52a5077084ccba
 `;
 
-const processInputs = votes => ({ passphrase, secondPassphrase }) =>
-	transactions.castVotes({ passphrase, delegates: votes, secondPassphrase });
+const processInputs = (votes, unvotes) => ({ passphrase, secondPassphrase }) =>
+	transactions.castVotes({ passphrase, votes, unvotes, secondPassphrase });
 
 const processVotesInput = async votes =>
 	votes.includes(':') ? getData(votes) : votes;
@@ -75,8 +75,7 @@ export const actionCreator = vorpal => async ({ options }) => {
 		? validatePublicKeys(processVotes(processedUnvotesInput))
 		: [];
 
-	const allVotes = [...validatedVotes, ...validatedUnvotes];
-	const processFunction = processInputs(allVotes);
+	const processFunction = processInputs(validatedVotes, validatedUnvotes);
 
 	return signature === false
 		? processFunction({ passphrase: null, secondPassphrase: null })

--- a/src/commands/create_transaction_cast_votes.js
+++ b/src/commands/create_transaction_cast_votes.js
@@ -16,12 +16,7 @@
 import { ValidationError } from '../utils/error';
 import getInputsFromSources from '../utils/input';
 import { getData } from '../utils/input/utils';
-import {
-	createCommand,
-	prependPlusToPublicKeys,
-	prependMinusToPublicKeys,
-	validatePublicKeys,
-} from '../utils/helpers';
+import { createCommand, validatePublicKeys } from '../utils/helpers';
 import commonOptions from '../utils/options';
 import transactions from '../utils/transactions';
 
@@ -75,19 +70,12 @@ export const actionCreator = vorpal => async ({ options }) => {
 
 	const validatedVotes = processedVotesInput
 		? validatePublicKeys(processVotes(processedVotesInput))
-		: null;
+		: [];
 	const validatedUnvotes = processedUnvotesInput
 		? validatePublicKeys(processVotes(processedUnvotesInput))
-		: null;
-
-	const prependedVotes = processedVotesInput
-		? prependPlusToPublicKeys(validatedVotes)
-		: [];
-	const prependedUnvotes = processedUnvotesInput
-		? prependMinusToPublicKeys(validatedUnvotes)
 		: [];
 
-	const allVotes = [...prependedVotes, ...prependedUnvotes];
+	const allVotes = [...validatedVotes, ...validatedUnvotes];
 	const processFunction = processInputs(allVotes);
 
 	return signature === false

--- a/src/commands/create_transaction_register_multisignature_account.js
+++ b/src/commands/create_transaction_register_multisignature_account.js
@@ -15,7 +15,6 @@
  */
 import {
 	createCommand,
-	prependPlusToPublicKeys,
 	validateLifetime,
 	validateMinimum,
 	validatePublicKeys,
@@ -59,7 +58,6 @@ export const actionCreator = vorpal => async ({
 	} = options;
 
 	const publicKeys = validatePublicKeys(keysgroup);
-	const publicKeysWithPlus = prependPlusToPublicKeys(publicKeys);
 
 	validateLifetime(lifetime);
 	validateMinimum(minimum);
@@ -69,7 +67,7 @@ export const actionCreator = vorpal => async ({
 	const processFunction = processInputs(
 		transactionLifetime,
 		transactionMinimumConfirmations,
-		publicKeysWithPlus,
+		publicKeys,
 	);
 
 	return signature === false

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -40,12 +40,6 @@ export const validatePublicKeys = publicKeys =>
 		return publicKey;
 	});
 
-export const prependPlusToPublicKeys = publicKeys =>
-	publicKeys.map(publicKey => `+${publicKey}`);
-
-export const prependMinusToPublicKeys = publicKeys =>
-	publicKeys.map(publicKey => `-${publicKey}`);
-
 const regExpAddress = /^\d{1,21}[L|l]$/;
 const regExpAmount = /^\d+(\.\d{1,8})?$/;
 

--- a/test/specs/commands/create_transaction_cast_votes.js
+++ b/test/specs/commands/create_transaction_cast_votes.js
@@ -544,8 +544,8 @@ describe('create transaction cast votes', () => {
 																					then.itShouldNotGetTheDataUsingTheUnvotesSource,
 																				);
 																				Then(
-																					'it should create a cast votes transaction with the passphrase and the public keys prepended with the correct modifier',
-																					then.itShouldCreateACastVoteTransactionWithThePassphraseAndThePublicKeysPrependedWithTheCorrectModifier,
+																					'it should create a cast votes transaction with the passphrase and the public keys to corresponding vote keys',
+																					then.itShouldCreateACastVoteTransactionWithThePassphraseAndThePublicKeysToCorrespondingVoteKeys,
 																				);
 																				Then(
 																					'it should resolve to the created transaction',
@@ -592,8 +592,8 @@ describe('create transaction cast votes', () => {
 																									then.itShouldGetTheDataUsingTheUnvotesSource,
 																								);
 																								Then(
-																									'it should create a cast votes transaction with the passphrase and the public keys prepended with the correct modifier',
-																									then.itShouldCreateACastVoteTransactionWithThePassphraseAndThePublicKeysPrependedWithTheCorrectModifier,
+																									'it should create a cast votes transaction with the passphrase and the public keys to corresponding vote keys',
+																									then.itShouldCreateACastVoteTransactionWithThePassphraseAndThePublicKeysToCorrespondingVoteKeys,
 																								);
 																								Then(
 																									'it should resolve to the created transaction',

--- a/test/specs/commands/create_transaction_cast_votes.js
+++ b/test/specs/commands/create_transaction_cast_votes.js
@@ -74,8 +74,8 @@ describe('create transaction cast votes', () => {
 																			then.itShouldNotGetTheDataUsingTheUnvotesSource,
 																		);
 																		Then(
-																			'it should create a cast votes transaction with the passphrase and the public keys prepended with a plus',
-																			then.itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysPrependedWithAPlus,
+																			'it should create a cast votes transaction with the passphrase and the public keys added to votes',
+																			then.itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysAddedToVotes,
 																		);
 																		Then(
 																			'it should resolve to the created transaction',
@@ -120,8 +120,8 @@ describe('create transaction cast votes', () => {
 																			then.itShouldNotGetTheDataUsingTheUnvotesSource,
 																		);
 																		Then(
-																			'it should create a cast votes transaction with the passphrase and the public keys prepended with a minus',
-																			then.itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysPrependedWithAMinus,
+																			'it should create a cast votes transaction with the passphrase and the public keys added to unvotes',
+																			then.itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysAddedToUnvotes,
 																		);
 																		Then(
 																			'it should resolve to the created transaction',
@@ -312,8 +312,8 @@ describe('create transaction cast votes', () => {
 																					then.itShouldNotGetTheDataUsingTheVotesSource,
 																				);
 																				Then(
-																					'it should create a cast votes transaction with the passphrase and the public keys prepended with a plus',
-																					then.itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysPrependedWithAPlus,
+																					'it should create a cast votes transaction with the passphrase and the public keys added to votes',
+																					then.itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysAddedToVotes,
 																				);
 																				Then(
 																					'it should resolve to the created transaction',
@@ -348,8 +348,8 @@ describe('create transaction cast votes', () => {
 																					then.itShouldNotGetTheDataUsingTheUnvotesSource,
 																				);
 																				Then(
-																					'it should create a cast votes transaction with the passphrase and the public keys prepended with a minus',
-																					then.itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysPrependedWithAMinus,
+																					'it should create a cast votes transaction with the passphrase and the public keys added to unvotes',
+																					then.itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysAddedToUnvotes,
 																				);
 																				Then(
 																					'it should resolve to the created transaction',
@@ -384,8 +384,8 @@ describe('create transaction cast votes', () => {
 																					then.itShouldNotGetTheDataUsingTheVotesSource,
 																				);
 																				Then(
-																					'it should create a cast votes transaction with the passphrase and the public keys prepended with a plus',
-																					then.itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysPrependedWithAPlus,
+																					'it should create a cast votes transaction with the passphrase and the public keys added to votes',
+																					then.itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysAddedToVotes,
 																				);
 																				Then(
 																					'it should resolve to the created transaction',
@@ -424,8 +424,8 @@ describe('create transaction cast votes', () => {
 																							then.itShouldGetTheDataUsingTheVotesSource,
 																						);
 																						Then(
-																							'it should create a cast votes transaction with the passphrase and the public keys prepended with a plus',
-																							then.itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysPrependedWithAPlus,
+																							'it should create a cast votes transaction with the passphrase and the public keys added to votes',
+																							then.itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysAddedToVotes,
 																						);
 																						Then(
 																							'it should resolve to the created transaction',
@@ -462,8 +462,8 @@ describe('create transaction cast votes', () => {
 																					then.itShouldNotGetTheDataUsingTheUnvotesSource,
 																				);
 																				Then(
-																					'it should create a cast votes transaction with the passphrase and the public keys prepended with a minus',
-																					then.itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysPrependedWithAMinus,
+																					'it should create a cast votes transaction with the passphrase and the public keys added to unvotes',
+																					then.itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysAddedToUnvotes,
 																				);
 																				Then(
 																					'it should resolve to the created transaction',
@@ -502,8 +502,8 @@ describe('create transaction cast votes', () => {
 																							then.itShouldGetTheDataUsingTheUnvotesSource,
 																						);
 																						Then(
-																							'it should create a cast votes transaction with the passphrase and the public keys prepended with a minus',
-																							then.itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysPrependedWithAMinus,
+																							'it should create a cast votes transaction with the passphrase and the public keys added to unvotes',
+																							then.itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysAddedToUnvotes,
 																						);
 																						Then(
 																							'it should resolve to the created transaction',
@@ -642,8 +642,8 @@ describe('create transaction cast votes', () => {
 																							then.itShouldGetTheDataUsingTheVotesSource,
 																						);
 																						Then(
-																							'it should create a cast votes transaction with the passphrase and the public keys prepended with a plus',
-																							then.itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysPrependedWithAPlus,
+																							'it should create a cast votes transaction with the passphrase and the public keys added to votes',
+																							then.itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysAddedToVotes,
 																						);
 																						Then(
 																							'it should resolve to the created transaction',
@@ -690,8 +690,8 @@ describe('create transaction cast votes', () => {
 																							then.itShouldGetTheDataUsingTheVotesSource,
 																						);
 																						Then(
-																							'it should create a cast votes transaction with the passphrase, the second passphrase and the public keys prepended with a plus',
-																							then.itShouldCreateACastVotesTransactionWithThePassphraseTheSecondPassphraseAndThePublicKeysPrependedWithAPlus,
+																							'it should create a cast votes transaction with the passphrase, the second passphrase and the public keys added to votes',
+																							then.itShouldCreateACastVotesTransactionWithThePassphraseTheSecondPassphraseAndThePublicKeysAddedToVotes,
 																						);
 																						Then(
 																							'it should resolve to the created transaction',
@@ -738,8 +738,8 @@ describe('create transaction cast votes', () => {
 																							then.itShouldGetTheDataUsingTheUnvotesSource,
 																						);
 																						Then(
-																							'it should create a cast votes transaction with the passphrase and the public keys prepended with a minus',
-																							then.itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysPrependedWithAMinus,
+																							'it should create a cast votes transaction with the passphrase and the public keys added to unvotes',
+																							then.itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysAddedToUnvotes,
 																						);
 																						Then(
 																							'it should resolve to the created transaction',
@@ -786,8 +786,8 @@ describe('create transaction cast votes', () => {
 																							then.itShouldGetTheDataUsingTheUnvotesSource,
 																						);
 																						Then(
-																							'it should create a cast votes transaction with the passphrase, the second passphrase and the public keys prepended with a minus',
-																							then.itShouldCreateACastVotesTransactionWithThePassphraseTheSecondPassphraseAndThePublicKeysPrependedWithAMinus,
+																							'it should create a cast votes transaction with the passphrase, the second passphrase and the public keys added to unvotes',
+																							then.itShouldCreateACastVotesTransactionWithThePassphraseTheSecondPassphraseAndThePublicKeysAddedToUnvotes,
 																						);
 																						Then(
 																							'it should resolve to the created transaction',
@@ -822,8 +822,8 @@ describe('create transaction cast votes', () => {
 											when.theActionIsCalledWithTheOptions,
 											() => {
 												Then(
-													'it should create a cast votes transaction with the the public keys prepended with a plus',
-													then.itShouldCreateACastVotesTransactionWithThePublicKeysPrependedWithAPlus,
+													'it should create a cast votes transaction with the the public keys added to votes',
+													then.itShouldCreateACastVotesTransactionWithThePublicKeysAddedToVotes,
 												);
 												Then(
 													'it should resolve to the created transaction',

--- a/test/specs/utils/helpers.js
+++ b/test/specs/utils/helpers.js
@@ -88,42 +88,6 @@ describe('utils helpers', () => {
 			},
 		);
 	});
-	describe('#prependPlusToPublicKeys', () => {
-		Given(
-			'public keys "647aac1e2df8a5c870499d7ddc82236b1e10936977537a3844a6b05ea33f9ef6" and "96d78cb7d246dd3b426182763e464301835787e1fe8342532660eba75b6b97fc"',
-			given.publicKeys,
-			() => {
-				When(
-					'prependPlusToPublicKeys is called with the public keys',
-					when.prependPlusToPublicKeysIsCalledWithThePublicKeys,
-					() => {
-						Then(
-							'it should return the public keys prepended with a plus',
-							then.itShouldReturnThePublicKeyPrependedWithAPlus,
-						);
-					},
-				);
-			},
-		);
-	});
-	describe('#prependMinusToPublicKeys', () => {
-		Given(
-			'public keys "647aac1e2df8a5c870499d7ddc82236b1e10936977537a3844a6b05ea33f9ef6" and "96d78cb7d246dd3b426182763e464301835787e1fe8342532660eba75b6b97fc"',
-			given.publicKeys,
-			() => {
-				When(
-					'prependMinusToPublicKeys is called with the public keys',
-					when.prependMinusToPublicKeysIsCalledWithThePublicKeys,
-					() => {
-						Then(
-							'it should return the public keys prepended with a minus',
-							then.itShouldReturnThePublicKeyPrependedWithAMinus,
-						);
-					},
-				);
-			},
-		);
-	});
 	describe('#validateLifetime', () => {
 		Given(
 			'a string lifetime of "1234567890" hours',

--- a/test/steps/domain/1_given.js
+++ b/test/steps/domain/1_given.js
@@ -118,19 +118,11 @@ export function aVariable() {
 
 export const anUnknownVariable = aVariable;
 
-export function aBlockID() {
-	this.test.ctx.blockID = getFirstQuotedString(this.test.parent.title);
-}
-
 export function anAddress() {
 	this.test.ctx.address = getFirstQuotedString(this.test.parent.title);
 }
 
 export const anInvalidAddress = anAddress;
-
-export function aTransactionID() {
-	this.test.ctx.transactionId = getFirstQuotedString(this.test.parent.title);
-}
 
 export function aDelegateUsername() {
 	this.test.ctx.delegateUsername = getFirstQuotedString(this.test.parent.title);

--- a/test/steps/domain/2_when.js
+++ b/test/steps/domain/2_when.js
@@ -15,28 +15,12 @@
  */
 import {
 	deAlias,
-	prependMinusToPublicKeys,
-	prependPlusToPublicKeys,
 	validateAddress,
 	validateAmount,
 	validateLifetime,
 	validateMinimum,
 	validatePublicKeys,
 } from '../../../src/utils/helpers';
-
-export function prependMinusToPublicKeysIsCalledWithThePublicKeys() {
-	const { publicKeys } = this.test.ctx;
-	const returnValue = prependMinusToPublicKeys(publicKeys);
-	this.test.ctx.returnValue = returnValue;
-	return returnValue;
-}
-
-export function prependPlusToPublicKeysIsCalledWithThePublicKeys() {
-	const { publicKeys } = this.test.ctx;
-	const returnValue = prependPlusToPublicKeys(publicKeys);
-	this.test.ctx.returnValue = returnValue;
-	return returnValue;
-}
 
 export function validatePublicKeysIsCalledWithThePublicKeys() {
 	const { publicKeys } = this.test.ctx;

--- a/test/steps/domain/3_then.js
+++ b/test/steps/domain/3_then.js
@@ -19,11 +19,6 @@ export function itShouldReturnThePublicKeys() {
 	return expect(returnValue).to.eql(publicKeys);
 }
 
-export function itShouldReturnTheBlock() {
-	const { returnValue, block } = this.test.ctx;
-	return expect(returnValue).to.equal(block);
-}
-
 export function itShouldReturnAnObjectWithTheAddress() {
 	const { returnValue, address } = this.test.ctx;
 	return expect(returnValue).to.eql({ address });

--- a/test/steps/domain/3_then.js
+++ b/test/steps/domain/3_then.js
@@ -14,22 +14,6 @@
  *
  */
 
-export function itShouldReturnThePublicKeyPrependedWithAMinus() {
-	const { publicKeys, returnValue } = this.test.ctx;
-	const publicKeysWithMinus = publicKeys.map(publicKey => {
-		return `-${publicKey}`;
-	});
-	return expect(returnValue).to.eql(publicKeysWithMinus);
-}
-
-export function itShouldReturnThePublicKeyPrependedWithAPlus() {
-	const { publicKeys, returnValue } = this.test.ctx;
-	const publicKeysWithPlus = publicKeys.map(publicKey => {
-		return `+${publicKey}`;
-	});
-	return expect(returnValue).to.eql(publicKeysWithPlus);
-}
-
 export function itShouldReturnThePublicKeys() {
 	const { returnValue, publicKeys } = this.test.ctx;
 	return expect(returnValue).to.eql(publicKeys);

--- a/test/steps/general/3_then.js
+++ b/test/steps/general/3_then.js
@@ -31,11 +31,6 @@ export function theErrorShouldHaveTheName() {
 	return expect(name).to.equal(errorName);
 }
 
-export function itShouldReturnTheResult() {
-	const { returnValue, result } = this.test.ctx;
-	return expect(returnValue).to.equal(result);
-}
-
 export function itShouldThrowValidationError() {
 	const { testFunction } = this.test.ctx;
 	const message = getFirstQuotedString(this.test.title);
@@ -69,11 +64,6 @@ export function itShouldExitWithCode() {
 export function itShouldResolveToAnObject() {
 	const { returnValue } = this.test.ctx;
 	return expect(returnValue).to.eventually.be.an('object');
-}
-
-export function itShouldResolveToAnEmptyObject() {
-	const { returnValue } = this.test.ctx;
-	return expect(returnValue).to.eventually.be.eql({});
 }
 
 export function itShouldResolveToTheErrorObject() {
@@ -135,11 +125,6 @@ export function itShouldRejectWithMessage() {
 	const { returnValue } = this.test.ctx;
 	const message = getFirstQuotedString(this.test.title);
 	return expect(returnValue).to.be.rejectedWith(message);
-}
-
-export function itShouldRejectWithTheOriginalRejection() {
-	const { returnValue, rejection } = this.test.ctx;
-	return expect(returnValue).to.be.rejectedWith(rejection);
 }
 
 export function itShouldReturnAnEmptyObject() {

--- a/test/steps/printing/2_when.js
+++ b/test/steps/printing/2_when.js
@@ -68,15 +68,9 @@ export function theObjectIsTablified() {
 
 export function theArrayIsTablified() {
 	const { testArray } = this.test.ctx;
-	try {
-		const returnValue = tablify(testArray);
-		this.test.ctx.returnValue = returnValue;
-		return returnValue;
-	} catch (error) {
-		const testFunction = tablify.bind(null, testArray);
-		this.test.ctx.testFunction = testFunction;
-		return testFunction;
-	}
+	const returnValue = tablify(testArray);
+	this.test.ctx.returnValue = returnValue;
+	return returnValue;
 }
 
 export function shouldUseJSONOutputIsCalledWithTheConfigAndOptions() {

--- a/test/steps/queries/1_given.js
+++ b/test/steps/queries/1_given.js
@@ -28,17 +28,3 @@ export function anEndpoint() {
 	const endpoint = getFirstQuotedString(this.test.parent.title);
 	this.test.ctx.endpoint = endpoint;
 }
-
-export function aResultWithError() {
-	const error = getFirstQuotedString(this.test.parent.title);
-	const result = { error };
-	this.test.ctx.result = result;
-}
-
-export function aResultWithABlock() {
-	const block = { height: 123 };
-	const result = { block };
-
-	this.test.ctx.block = block;
-	this.test.ctx.result = result;
-}

--- a/test/steps/queries/2_when.js
+++ b/test/steps/queries/2_when.js
@@ -13,17 +13,16 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { processQueryResult } from '../../../src/utils/helpers';
 import query from '../../../src/utils/query';
 
 export function theQueryInstanceSendsARequestAndTheLiskAPIInstanceResolvesWithASuccessfulArrayDataResponse() {
 	const { liskAPIInstance, endpoint, parameters, options } = this.test.ctx;
 
-	const sendRequestResult = {
+	const queryResult = {
 		data: [{ some: 'value' }],
 	};
-	liskAPIInstance[endpoint].get.resolves(sendRequestResult);
-	this.test.ctx.sendRequestResult = sendRequestResult;
+	liskAPIInstance[endpoint].get.resolves(queryResult);
+	this.test.ctx.queryResult = queryResult;
 
 	const returnValue = query(endpoint, parameters, options);
 	this.test.ctx.returnValue = returnValue;
@@ -34,11 +33,11 @@ export function theQueryInstanceSendsARequestAndTheLiskAPIInstanceResolvesWithAS
 export function theQueryInstanceSendsARequestAndTheLiskAPIInstanceResolvesWithASuccessfulObjectDataResponse() {
 	const { liskAPIInstance, endpoint, parameters, options } = this.test.ctx;
 
-	const sendRequestResult = {
+	const queryResult = {
 		data: { message: 'value' },
 	};
-	liskAPIInstance[endpoint].get.resolves(sendRequestResult);
-	this.test.ctx.sendRequestResult = sendRequestResult;
+	liskAPIInstance[endpoint].get.resolves(queryResult);
+	this.test.ctx.queryResult = queryResult;
 
 	const returnValue = query(endpoint, parameters, options);
 	this.test.ctx.returnValue = returnValue;
@@ -49,11 +48,11 @@ export function theQueryInstanceSendsARequestAndTheLiskAPIInstanceResolvesWithAS
 export function theQueryInstanceSendsARequestAndTheLiskAPIInstanceResolvesWithAFailedResponse() {
 	const { liskAPIInstance, endpoint, parameters, options } = this.test.ctx;
 
-	const sendRequestResult = {
+	const queryResult = {
 		message: 'request failed',
 	};
-	liskAPIInstance[endpoint].get.resolves(sendRequestResult);
-	this.test.ctx.sendRequestResult = sendRequestResult;
+	liskAPIInstance[endpoint].get.resolves(queryResult);
+	this.test.ctx.queryResult = queryResult;
 
 	const returnValue = query(endpoint, parameters, options);
 	this.test.ctx.returnValue = returnValue;
@@ -64,89 +63,14 @@ export function theQueryInstanceSendsARequestAndTheLiskAPIInstanceResolvesWithAF
 export function theQueryInstanceSendsARequestAndTheLiskAPIInstanceResolvesWithASuccessfulEmptyArrayDataResponse() {
 	const { liskAPIInstance, endpoint, parameters, options } = this.test.ctx;
 
-	const sendRequestResult = {
+	const queryResult = {
 		data: [],
 	};
-	liskAPIInstance[endpoint].get.resolves(sendRequestResult);
-	this.test.ctx.sendRequestResult = sendRequestResult;
+	liskAPIInstance[endpoint].get.resolves(queryResult);
+	this.test.ctx.queryResult = queryResult;
 
 	const returnValue = query(endpoint, parameters, options);
 	this.test.ctx.returnValue = returnValue;
 
 	return returnValue.catch(e => e);
-}
-
-export function theQueryInstanceSendsARequestUsingTheEndpointAndTheParameters() {
-	const { queryInstance, endpoint, parameters } = this.test.ctx;
-	const returnValue = queryInstance.sendRequest(endpoint, parameters);
-	this.test.ctx.returnValue = returnValue;
-	return returnValue.catch(e => e);
-}
-
-export function theQueryInstanceSendsARequestUsingTheEndpointTheParametersAndTheOptions() {
-	const { queryInstance, endpoint, parameters, options } = this.test.ctx;
-	const returnValue = queryInstance.sendRequest(endpoint, parameters, options);
-	this.test.ctx.returnValue = returnValue;
-	return returnValue.catch(e => e);
-}
-
-export function aRejectionOccursSendingARequestUsingTheEndpointAndTheParameters() {
-	const {
-		liskAPIInstance,
-		queryInstance,
-		endpoint,
-		parameters,
-	} = this.test.ctx;
-
-	const rejection = { error: 'oh no' };
-	this.test.ctx.rejection = rejection;
-	liskAPIInstance.sendRequest.rejects(rejection);
-
-	const returnValue = queryInstance.sendRequest(endpoint, parameters);
-	this.test.ctx.returnValue = returnValue;
-	return returnValue.catch(e => e);
-}
-
-export function aRejectionOccursSendingARequestUsingTheEndpointTheParametersAndTheOptions() {
-	const {
-		liskAPIInstance,
-		queryInstance,
-		endpoint,
-		parameters,
-		options,
-	} = this.test.ctx;
-
-	const rejection = { error: 'oh no' };
-	this.test.ctx.rejection = rejection;
-	liskAPIInstance.sendRequest.rejects(rejection);
-
-	const returnValue = queryInstance.sendRequest(endpoint, parameters, options);
-	this.test.ctx.returnValue = returnValue;
-	return returnValue.catch(e => e);
-}
-
-export function processQueryResultIsCalledWithTheTypeThenTheResult() {
-	const { type, result } = this.test.ctx;
-	const returnValue = processQueryResult(type)(result);
-	this.test.ctx.returnValue = returnValue;
-}
-
-export function theQueryInstanceGetsABlockUsingTheID() {
-	const { queryInstance, blockId } = this.test.ctx;
-	this.test.ctx.returnValue = queryInstance.getBlock(blockId);
-}
-
-export function theQueryInstanceGetsAnAccountUsingTheAddress() {
-	const { queryInstance, address } = this.test.ctx;
-	this.test.ctx.returnValue = queryInstance.getAccount(address);
-}
-
-export function theQueryInstanceGetsATransactionUsingTheID() {
-	const { queryInstance, transactionId } = this.test.ctx;
-	this.test.ctx.returnValue = queryInstance.getTransaction(transactionId);
-}
-
-export function theQueryInstanceGetsADelegateUsingTheUsername() {
-	const { queryInstance, delegateUsername } = this.test.ctx;
-	this.test.ctx.returnValue = queryInstance.getDelegate(delegateUsername);
 }

--- a/test/steps/queries/3_then.js
+++ b/test/steps/queries/3_then.js
@@ -14,19 +14,14 @@
  *
  */
 
-export function itShouldResolveToTheResultOfSendingTheRequest() {
-	const { returnValue, sendRequestResult } = this.test.ctx;
-	return expect(returnValue).to.eventually.equal(sendRequestResult);
-}
-
 export function itShouldResolveToTheDataOfTheResponse() {
-	const { returnValue, sendRequestResult } = this.test.ctx;
-	return expect(returnValue).to.eventually.equal(sendRequestResult.data);
+	const { returnValue, queryResult } = this.test.ctx;
+	return expect(returnValue).to.eventually.equal(queryResult.data);
 }
 
 export function itShouldResolveToTheFirstElementOfDataOfTheResponse() {
-	const { returnValue, sendRequestResult } = this.test.ctx;
-	return expect(returnValue).to.eventually.equal(sendRequestResult.data[0]);
+	const { returnValue, queryResult } = this.test.ctx;
+	return expect(returnValue).to.eventually.equal(queryResult.data[0]);
 }
 
 export function itShouldResolveToTheResultOfTheQuery() {

--- a/test/steps/setup.js
+++ b/test/steps/setup.js
@@ -80,32 +80,32 @@ const setUpReadlineStubs = () => {
 };
 
 function setUpLiskJSAPIStubs() {
-	const sendRequestDefaultResult = { success: true };
+	const queryDefaultResult = { success: true };
 	const broadcastTransactionResponse = {
 		message: 'Transaction accepted by the node for processing',
 	};
 	const broadcastSignaturesResponse = {
 		message: 'Signature is accepted by the node for processing',
 	};
-	this.test.ctx.sendRequestResult = sendRequestDefaultResult;
+	this.test.ctx.queryResult = queryDefaultResult;
 	this.test.ctx.broadcastTransactionResponse = broadcastTransactionResponse;
 	this.test.ctx.broadcastSignaturesResponse = broadcastSignaturesResponse;
 	sandbox.stub(getAPIClient, 'default').returns({
 		delegates: {
-			get: sandbox.stub().resolves(sendRequestDefaultResult),
+			get: sandbox.stub().resolves(queryDefaultResult),
 		},
 		blocks: {
-			get: sandbox.stub().resolves(sendRequestDefaultResult),
+			get: sandbox.stub().resolves(queryDefaultResult),
 		},
 		accounts: {
-			get: sandbox.stub().resolves(sendRequestDefaultResult),
+			get: sandbox.stub().resolves(queryDefaultResult),
 		},
 		transactions: {
-			get: sandbox.stub().resolves(sendRequestDefaultResult),
+			get: sandbox.stub().resolves(queryDefaultResult),
 			broadcast: sandbox.stub().resolves(broadcastTransactionResponse),
 		},
 		signatures: {
-			get: sandbox.stub().resolves(sendRequestDefaultResult),
+			get: sandbox.stub().resolves(queryDefaultResult),
 			broadcast: sandbox.stub().resolves(broadcastSignaturesResponse),
 		},
 	});

--- a/test/steps/transactions/3_then.js
+++ b/test/steps/transactions/3_then.js
@@ -16,57 +16,62 @@
 import transactions from '../../../src/utils/transactions';
 import { getNumbers, getTransactionCreatorFunctionNameByType } from '../utils';
 
-export function itShouldCreateACastVotesTransactionWithThePassphraseTheSecondPassphraseAndThePublicKeysPrependedWithAMinus() {
+export function itShouldCreateACastVotesTransactionWithThePassphraseTheSecondPassphraseAndThePublicKeysAddedToUnvotes() {
 	const { passphrase, secondPassphrase, unvotePublicKeys } = this.test.ctx;
 	return expect(transactions.castVotes).to.be.calledWithExactly({
 		passphrase,
-		delegates: unvotePublicKeys,
+		votes: [],
+		unvotes: unvotePublicKeys,
 		secondPassphrase,
 	});
 }
 
-export function itShouldCreateACastVotesTransactionWithThePassphraseTheSecondPassphraseAndThePublicKeysPrependedWithAPlus() {
+export function itShouldCreateACastVotesTransactionWithThePassphraseTheSecondPassphraseAndThePublicKeysAddedToVotes() {
 	const { passphrase, secondPassphrase, votePublicKeys } = this.test.ctx;
 	return expect(transactions.castVotes).to.be.calledWithExactly({
 		passphrase,
-		delegates: votePublicKeys,
+		votes: votePublicKeys,
+		unvotes: [],
 		secondPassphrase,
 	});
 }
 
 export function itShouldCreateACastVoteTransactionWithThePassphraseAndThePublicKeysPrependedWithTheCorrectModifier() {
 	const { passphrase, votePublicKeys, unvotePublicKeys } = this.test.ctx;
-	const allVotes = [...votePublicKeys, ...unvotePublicKeys];
 	return expect(transactions.castVotes).to.be.calledWithExactly({
 		passphrase,
-		delegates: allVotes,
+		votes: votePublicKeys,
+		unvotes: unvotePublicKeys,
 		secondPassphrase: null,
 	});
 }
 
-export function itShouldCreateACastVotesTransactionWithThePublicKeysPrependedWithAPlus() {
+export function itShouldCreateACastVotesTransactionWithThePublicKeysAddedToVotes() {
 	const { votePublicKeys } = this.test.ctx;
 	return expect(transactions.castVotes).to.be.calledWithExactly({
 		passphrase: null,
-		delegates: votePublicKeys,
+		votes: votePublicKeys,
+		unvotes: [],
 		secondPassphrase: null,
 	});
 }
 
-export function itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysPrependedWithAMinus() {
+export function itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysAddedToUnvotes() {
 	const { passphrase, unvotePublicKeys } = this.test.ctx;
 	return expect(transactions.castVotes).to.be.calledWithExactly({
 		passphrase,
-		delegates: unvotePublicKeys,
+		votes: [],
+		unvotes: unvotePublicKeys,
 		secondPassphrase: null,
 	});
 }
 
-export function itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysPrependedWithAPlus() {
+export function itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysAddedToVotes() {
 	const { passphrase, votePublicKeys } = this.test.ctx;
 	return expect(transactions.castVotes).to.be.calledWithExactly({
 		passphrase,
-		delegates: votePublicKeys,
+		votes: votePublicKeys,
+		unvotes: [],
 		secondPassphrase: null,
 	});
 }

--- a/test/steps/transactions/3_then.js
+++ b/test/steps/transactions/3_then.js
@@ -36,7 +36,7 @@ export function itShouldCreateACastVotesTransactionWithThePassphraseTheSecondPas
 	});
 }
 
-export function itShouldCreateACastVoteTransactionWithThePassphraseAndThePublicKeysPrependedWithTheCorrectModifier() {
+export function itShouldCreateACastVoteTransactionWithThePassphraseAndThePublicKeysToCorrespondingVoteKeys() {
 	const { passphrase, votePublicKeys, unvotePublicKeys } = this.test.ctx;
 	return expect(transactions.castVotes).to.be.calledWithExactly({
 		passphrase,

--- a/test/steps/transactions/3_then.js
+++ b/test/steps/transactions/3_then.js
@@ -15,36 +15,28 @@
  */
 import transactions from '../../../src/utils/transactions';
 import { getNumbers, getTransactionCreatorFunctionNameByType } from '../utils';
-import {
-	prependPlusToPublicKeys,
-	prependMinusToPublicKeys,
-} from '../../../src/utils/helpers';
 
 export function itShouldCreateACastVotesTransactionWithThePassphraseTheSecondPassphraseAndThePublicKeysPrependedWithAMinus() {
 	const { passphrase, secondPassphrase, unvotePublicKeys } = this.test.ctx;
-	const unvotes = prependMinusToPublicKeys(unvotePublicKeys);
 	return expect(transactions.castVotes).to.be.calledWithExactly({
 		passphrase,
-		delegates: unvotes,
+		delegates: unvotePublicKeys,
 		secondPassphrase,
 	});
 }
 
 export function itShouldCreateACastVotesTransactionWithThePassphraseTheSecondPassphraseAndThePublicKeysPrependedWithAPlus() {
 	const { passphrase, secondPassphrase, votePublicKeys } = this.test.ctx;
-	const votes = prependPlusToPublicKeys(votePublicKeys);
 	return expect(transactions.castVotes).to.be.calledWithExactly({
 		passphrase,
-		delegates: votes,
+		delegates: votePublicKeys,
 		secondPassphrase,
 	});
 }
 
 export function itShouldCreateACastVoteTransactionWithThePassphraseAndThePublicKeysPrependedWithTheCorrectModifier() {
 	const { passphrase, votePublicKeys, unvotePublicKeys } = this.test.ctx;
-	const votes = prependPlusToPublicKeys(votePublicKeys);
-	const unvotes = prependMinusToPublicKeys(unvotePublicKeys);
-	const allVotes = [...votes, ...unvotes];
+	const allVotes = [...votePublicKeys, ...unvotePublicKeys];
 	return expect(transactions.castVotes).to.be.calledWithExactly({
 		passphrase,
 		delegates: allVotes,
@@ -54,30 +46,27 @@ export function itShouldCreateACastVoteTransactionWithThePassphraseAndThePublicK
 
 export function itShouldCreateACastVotesTransactionWithThePublicKeysPrependedWithAPlus() {
 	const { votePublicKeys } = this.test.ctx;
-	const votes = prependPlusToPublicKeys(votePublicKeys);
 	return expect(transactions.castVotes).to.be.calledWithExactly({
 		passphrase: null,
-		delegates: votes,
+		delegates: votePublicKeys,
 		secondPassphrase: null,
 	});
 }
 
 export function itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysPrependedWithAMinus() {
 	const { passphrase, unvotePublicKeys } = this.test.ctx;
-	const unvotes = prependMinusToPublicKeys(unvotePublicKeys);
 	return expect(transactions.castVotes).to.be.calledWithExactly({
 		passphrase,
-		delegates: unvotes,
+		delegates: unvotePublicKeys,
 		secondPassphrase: null,
 	});
 }
 
 export function itShouldCreateACastVotesTransactionWithThePassphraseAndThePublicKeysPrependedWithAPlus() {
 	const { passphrase, votePublicKeys } = this.test.ctx;
-	const votes = prependPlusToPublicKeys(votePublicKeys);
 	return expect(transactions.castVotes).to.be.calledWithExactly({
 		passphrase,
-		delegates: votes,
+		delegates: votePublicKeys,
 		secondPassphrase: null,
 	});
 }

--- a/test/steps/transactions/3_then.js
+++ b/test/steps/transactions/3_then.js
@@ -173,13 +173,10 @@ export function itShouldCreateARegisterDelegateTransactionUsingThePassphraseTheS
 
 export function itShouldCreateARegisterMultisignatureAccountTransactionUsingTheKeysgroupTheLifetimeAndTheMinimumNumberOfSignatures() {
 	const { keysgroup, lifetime, minimum } = this.test.ctx;
-	const publicKeysWithPlus = keysgroup.map(publicKey => {
-		return `+${publicKey}`;
-	});
 	return expect(transactions.registerMultisignature).to.be.calledWithExactly({
 		passphrase: null,
 		secondPassphrase: null,
-		keysgroup: publicKeysWithPlus,
+		keysgroup,
 		lifetime,
 		minimum,
 	});
@@ -193,13 +190,10 @@ export function itShouldCreateARegisterMultisignatureAccountTransactionUsingTheP
 		lifetime,
 		minimum,
 	} = this.test.ctx;
-	const publicKeysWithPlus = keysgroup.map(publicKey => {
-		return `+${publicKey}`;
-	});
 	return expect(transactions.registerMultisignature).to.be.calledWithExactly({
 		passphrase,
 		secondPassphrase,
-		keysgroup: publicKeysWithPlus,
+		keysgroup,
 		lifetime,
 		minimum,
 	});
@@ -207,13 +201,10 @@ export function itShouldCreateARegisterMultisignatureAccountTransactionUsingTheP
 
 export function itShouldCreateARegisterMultisignatureAccountTransactionUsingThePassphraseTheKeysgroupTheLifetimeAndTheMinimumNumberOfSignatures() {
 	const { passphrase, keysgroup, lifetime, minimum } = this.test.ctx;
-	const publicKeysWithPlus = keysgroup.map(publicKey => {
-		return `+${publicKey}`;
-	});
 	return expect(transactions.registerMultisignature).to.be.calledWithExactly({
 		passphrase,
 		secondPassphrase: null,
-		keysgroup: publicKeysWithPlus,
+		keysgroup,
 		lifetime,
 		minimum,
 	});


### PR DESCRIPTION
### What was the problem?
`create transaction register multisignature account` did not work with error `{"error":"Could not create \"register multisignature account\" transaction: Argument must be a valid hex string."}`.

`Lisk-js` was expecting keygroup array without `+`.

merge after #461 

### How did I fix it?
Deleting appending `+` on the lisk-commander.

### How to test it?
try command from example
```
create transaction register multisignature account 24 2 215b667a32a5cd51a94c9c2046c11fffb08c65748febec099451e3b164452bca 922fbfdd596fa78269bbcadc67ec2a1cc15fc929a19c462169568d7a3df1a1aa
```

### Review checklist

* The PR solves #470 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
