### PR TITLE
Fix printing the array of objects - Closes #474

### DIFF
--- a/src/utils/print.js
+++ b/src/utils/print.js
@@ -19,8 +19,8 @@ import config from './config';
 import { shouldUseJSONOutput, shouldUsePrettyOutput } from './helpers';
 import tablify from './tablify';
 
-const removeANSIFromObject = result =>
-	Object.entries(result).reduce(
+const removeANSIFromObject = object =>
+	Object.entries(object).reduce(
 		(strippedResult, [key, value]) =>
 			Object.assign({}, strippedResult, { [key]: stripANSI(value) }),
 		{},
@@ -28,7 +28,7 @@ const removeANSIFromObject = result =>
 
 const removeANSI = result =>
 	Array.isArray(result)
-		? result.map(object => removeANSIFromObject(object))
+		? result.map(removeANSIFromObject)
 		: removeANSIFromObject(result);
 
 export const printResult = (vorpal, options = {}) =>

--- a/src/utils/print.js
+++ b/src/utils/print.js
@@ -19,12 +19,17 @@ import config from './config';
 import { shouldUseJSONOutput, shouldUsePrettyOutput } from './helpers';
 import tablify from './tablify';
 
-const removeANSI = result =>
+const removeANSIFromObject = result =>
 	Object.entries(result).reduce(
 		(strippedResult, [key, value]) =>
 			Object.assign({}, strippedResult, { [key]: stripANSI(value) }),
 		{},
 	);
+
+const removeANSI = result =>
+	Array.isArray(result)
+		? result.map(object => removeANSIFromObject(object))
+		: removeANSIFromObject(result);
 
 export const printResult = (vorpal, options = {}) =>
 	function print(result) {

--- a/test/specs/utils/print.js
+++ b/test/specs/utils/print.js
@@ -223,6 +223,162 @@ describe('print utils', () => {
 						},
 					);
 				});
+				Given(
+					'there are results to print',
+					given.thereAreResultsToPrint,
+					() => {
+						Given(
+							'a config with json set to true',
+							given.aConfigWithJsonSetTo,
+							() => {
+								Given(
+									'an options object with json set to false',
+									given.anOptionsObjectWithJsonSetTo,
+									() => {
+										Given(
+											'JSON should be printed',
+											given.jsonShouldBePrinted,
+											() => {
+												Given(
+													'output should not be pretty',
+													given.outputShouldNotBePretty,
+													() => {
+														When(
+															'the results are printed',
+															when.theResultsArePrinted,
+															() => {
+																Then(
+																	'shouldUseJSONOutput should be called with the config and the options',
+																	then.shouldUseJSONOutputShouldBeCalledWithTheConfigAndTheOptions,
+																);
+																Then(
+																	'shouldUsePrettyOutput should be called with the config and the options',
+																	then.shouldUsePrettyOutputShouldBeCalledWithTheConfigAndTheOptions,
+																);
+																Then(
+																	'JSON outputs should be logged without ANSI codes',
+																	then.jsonOutputsShouldBeLoggedWithoutANSICodes,
+																);
+															},
+														);
+													},
+												);
+												Given(
+													'the options object has key "pretty" set to boolean true',
+													given.theOptionsObjectHasKeySetToBoolean,
+													() => {
+														Given(
+															'output should be pretty',
+															given.outputShouldBePretty,
+															() => {
+																When(
+																	'the results are printed',
+																	when.theResultsArePrinted,
+																	() => {
+																		Then(
+																			'shouldUseJSONOutput should be called with the config and the options',
+																			then.shouldUseJSONOutputShouldBeCalledWithTheConfigAndTheOptions,
+																		);
+																		Then(
+																			'shouldUsePrettyOutput should be called with the config and the options',
+																			then.shouldUsePrettyOutputShouldBeCalledWithTheConfigAndTheOptions,
+																		);
+																		Then(
+																			'pretty JSON outputs should be logged without ANSI codes',
+																			then.prettyJSONOutputsShouldBeLoggedWithoutANSICodes,
+																		);
+																	},
+																);
+															},
+														);
+													},
+												);
+											},
+										);
+									},
+								);
+							},
+						);
+						Given(
+							'a config with json set to true and pretty set to true',
+							given.aConfigWithJsonSetToAndPrettySetTo,
+							() => {
+								Given(
+									'an empty options object',
+									given.anEmptyOptionsObject,
+									() => {
+										Given(
+											'JSON should be printed',
+											given.jsonShouldBePrinted,
+											() => {
+												Given(
+													'output should be pretty',
+													given.outputShouldBePretty,
+													() => {
+														When(
+															'the results are printed',
+															when.theResultsArePrinted,
+															() => {
+																Then(
+																	'shouldUseJSONOutput should be called with the config and the options',
+																	then.shouldUseJSONOutputShouldBeCalledWithTheConfigAndTheOptions,
+																);
+																Then(
+																	'shouldUsePrettyOutput should be called with the config and the options',
+																	then.shouldUsePrettyOutputShouldBeCalledWithTheConfigAndTheOptions,
+																);
+																Then(
+																	'pretty JSON outputs should be logged without ANSI codes',
+																	then.prettyJSONOutputsShouldBeLoggedWithoutANSICodes,
+																);
+															},
+														);
+													},
+												);
+											},
+										);
+									},
+								);
+								Given(
+									'an options object with key "pretty" set to boolean false',
+									given.anOptionsObjectWithKeySetToBoolean,
+									() => {
+										Given(
+											'JSON should be printed',
+											given.jsonShouldBePrinted,
+											() => {
+												Given(
+													'output should not be pretty',
+													given.outputShouldNotBePretty,
+													() => {
+														When(
+															'the results are printed',
+															when.theResultsArePrinted,
+															() => {
+																Then(
+																	'shouldUseJSONOutput should be called with the config and the options',
+																	then.shouldUseJSONOutputShouldBeCalledWithTheConfigAndTheOptions,
+																);
+																Then(
+																	'shouldUsePrettyOutput should be called with the config and the options',
+																	then.shouldUsePrettyOutputShouldBeCalledWithTheConfigAndTheOptions,
+																);
+																Then(
+																	'JSON outputs should be logged without ANSI codes',
+																	then.jsonOutputsShouldBeLoggedWithoutANSICodes,
+																);
+															},
+														);
+													},
+												);
+											},
+										);
+									},
+								);
+							},
+						);
+					},
+				);
 			},
 		);
 	});

--- a/test/steps/printing/1_given.js
+++ b/test/steps/printing/1_given.js
@@ -23,6 +23,17 @@ export function thereIsAResultToPrint() {
 	this.test.ctx.resultWithoutANSICodes = { lisk: 'Some prefix: JS' };
 }
 
+export function thereAreResultsToPrint() {
+	this.test.ctx.results = [
+		{ lisk: 'Some prefix: \u001B[4mJS\u001B[0m' },
+		{ lisk: 'Some suffix: \u001B[4mawsome\u001B[0m' },
+	];
+	this.test.ctx.resultsWithoutANSICodes = [
+		{ lisk: 'Some prefix: JS' },
+		{ lisk: 'Some suffix: awsome' },
+	];
+}
+
 export function jsonShouldBePrinted() {
 	shouldUseJSONOutput.returns(true);
 }

--- a/test/steps/printing/2_when.js
+++ b/test/steps/printing/2_when.js
@@ -45,6 +45,11 @@ export function theResultIsPrinted() {
 	this.test.ctx.returnValue = printResult(vorpal, options)(result);
 }
 
+export function theResultsArePrinted() {
+	const { vorpal, results, options } = this.test.ctx;
+	this.test.ctx.returnValue = printResult(vorpal, options)(results);
+}
+
 export function theResultIsPrintedUsingTheActiveCommandContext() {
 	const { vorpal, result, options, activeCommand } = this.test.ctx;
 	this.test.ctx.returnValue = printResult(vorpal, options).call(

--- a/test/steps/printing/3_then.js
+++ b/test/steps/printing/3_then.js
@@ -90,6 +90,18 @@ export function jsonOutputShouldBeLoggedWithoutANSICodes() {
 	return expect(vorpal.log).to.be.calledWithExactly(jsonOutput);
 }
 
+export function prettyJSONOutputsShouldBeLoggedWithoutANSICodes() {
+	const { resultsWithoutANSICodes, vorpal } = this.test.ctx;
+	const prettyJSONOutput = JSON.stringify(resultsWithoutANSICodes, null, '\t');
+	return expect(vorpal.log).to.be.calledWithExactly(prettyJSONOutput);
+}
+
+export function jsonOutputsShouldBeLoggedWithoutANSICodes() {
+	const { resultsWithoutANSICodes, vorpal } = this.test.ctx;
+	const jsonOutput = JSON.stringify(resultsWithoutANSICodes);
+	return expect(vorpal.log).to.be.calledWithExactly(jsonOutput);
+}
+
 export function shouldUseJSONOutputShouldBeCalledWithTheConfigAndAnEmptyOptionsObject() {
 	const { config } = this.test.ctx;
 	return expect(shouldUseJSONOutput).to.be.calledWithExactly(config, {});


### PR DESCRIPTION
### What was the problem?
when removing ANSI, it was expecting object, but we were supplying an array.

### How did I fix it?
Check if the results are array or an object, and if an array go through removing ANSI process one by one.

### How to test it?
`lisky> list delegates genesis_1 genesis_5`
### Review checklist

* The PR solves #474 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
