### PR TITLE
Add set network command and remove testnet options - Closes #477

### DIFF
--- a/default_config.json
+++ b/default_config.json
@@ -2,8 +2,8 @@
 	"name": "lisky",
 	"json": false,
 	"api": {
-		"testnet": false,
-		"node": ""
+		"node": "",
+		"network": ""
 	},
 	"pretty": false
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"bip39": "=2.4.0",
 		"chalk": "=2.3.0",
 		"cli-table2": "=0.2.0",
-		"lisk-js": "LiskHQ/lisk-js#lisk-elements-1.0.0-RC3",
+		"lisk-js": "LiskHQ/lisk-js#lisk-elements-1.0.0-beta.1",
 		"lockfile": "=1.0.3",
 		"semver": "=5.5.0",
 		"strip-ansi": "=4.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"bip39": "=2.4.0",
 		"chalk": "=2.3.0",
 		"cli-table2": "=0.2.0",
-		"lisk-js": "LiskHQ/lisk-js#lisk-elements-1.0.0-beta.1",
+		"lisk-js": "beta",
 		"lockfile": "=1.0.3",
 		"semver": "=5.5.0",
 		"strip-ansi": "=4.0.0",

--- a/src/commands/get.js
+++ b/src/commands/get.js
@@ -16,7 +16,6 @@
 import { COMMAND_TYPES, PLURALS, QUERY_INPUT_MAP } from '../utils/constants';
 import { ValidationError } from '../utils/error';
 import { createCommand, deAlias } from '../utils/helpers';
-import commonOptions from '../utils/options';
 import query from '../utils/query';
 
 const description = `Gets information from the blockchain. Types available: account, address, block, delegate, transaction.
@@ -26,11 +25,7 @@ const description = `Gets information from the blockchain. Types available: acco
 	- get block 5510510593472232540
 `;
 
-export const actionCreator = () => async ({
-	type,
-	input,
-	options: { testnet },
-}) => {
+export const actionCreator = () => async ({ type, input }) => {
 	const pluralType = Object.keys(PLURALS).includes(type) ? PLURALS[type] : type;
 
 	if (!COMMAND_TYPES.includes(pluralType)) {
@@ -43,9 +38,7 @@ export const actionCreator = () => async ({
 		[QUERY_INPUT_MAP[endpoint]]: input,
 	};
 
-	return query(endpoint, req, {
-		testnet,
-	});
+	return query(endpoint, req);
 };
 
 const get = createCommand({
@@ -53,7 +46,6 @@ const get = createCommand({
 	autocomplete: COMMAND_TYPES,
 	description,
 	actionCreator,
-	options: [commonOptions.testnet],
 	errorPrefix: 'Could not get',
 });
 

--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -16,7 +16,6 @@
 import { COMMAND_TYPES, PLURALS, QUERY_INPUT_MAP } from '../utils/constants';
 import { ValidationError } from '../utils/error';
 import { createCommand, deAlias } from '../utils/helpers';
-import commonOptions from '../utils/options';
 import query from '../utils/query';
 
 const description = `Gets an array of information from the blockchain. Types available: accounts, addresses, blocks, delegates, transactions.
@@ -26,11 +25,7 @@ const description = `Gets an array of information from the blockchain. Types ava
 	- list blocks 5510510593472232540 16450842638530591789
 `;
 
-export const actionCreator = () => async ({
-	type,
-	inputs,
-	options: { testnet },
-}) => {
+export const actionCreator = () => async ({ type, inputs }) => {
 	const pluralType = Object.keys(PLURALS).includes(type) ? PLURALS[type] : type;
 
 	if (!COMMAND_TYPES.includes(pluralType)) {
@@ -44,7 +39,7 @@ export const actionCreator = () => async ({
 			limit: 1,
 			[QUERY_INPUT_MAP[endpoint]]: input,
 		};
-		return query(endpoint, req, { testnet });
+		return query(endpoint, req);
 	});
 
 	return Promise.all(queries);
@@ -55,7 +50,6 @@ const list = createCommand({
 	autocomplete: COMMAND_TYPES,
 	description,
 	actionCreator,
-	options: [commonOptions.testnet],
 	errorPrefix: 'Could not list',
 });
 

--- a/src/commands/set.js
+++ b/src/commands/set.js
@@ -13,7 +13,8 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { CONFIG_VARIABLES } from '../utils/constants';
+import lisk from 'lisk-js';
+import { CONFIG_VARIABLES, NETHASHES } from '../utils/constants';
 import config, { configFilePath } from '../utils/config';
 import { FileSystemError, ValidationError } from '../utils/error';
 import { writeJSONSync } from '../utils/fs';
@@ -25,7 +26,7 @@ const description = `Sets configuration <variable> to <value>. Variables availab
 	Examples:
 	- set json true
 	- set name my_custom_lisky
-	- set api.testnet true
+	- set api.network main
 `;
 
 const WRITE_FAIL_WARNING =
@@ -98,9 +99,30 @@ const setString = (dotNotation, value) => {
 	return attemptWriteToFile(value, dotNotation);
 };
 
+const setNethash = (dotNotation, value) => {
+	if (
+		dotNotation === 'api.network' &&
+		!Object.keys(NETHASHES).includes(value)
+	) {
+		if (value.length !== 64) {
+			throw new ValidationError(
+				'Value must be a hex string with 64 characters.',
+			);
+		}
+		try {
+			lisk.cryptography.hexToBuffer(value, 'utf8');
+		} catch (error) {
+			throw new ValidationError(
+				'Value must be a hex string with 64 characters.',
+			);
+		}
+	}
+	return setString(dotNotation, value);
+};
+
 const handlers = {
 	'api.node': setString,
-	'api.testnet': setBoolean,
+	'api.network': setNethash,
 	json: setBoolean,
 	name: setString,
 	pretty: setBoolean,

--- a/src/commands/set.js
+++ b/src/commands/set.js
@@ -32,6 +32,9 @@ const description = `Sets configuration <variable> to <value>. Variables availab
 const WRITE_FAIL_WARNING =
 	'Config file could not be written: your changes will not be persisted.';
 
+const NETHASH_ERROR_MESSAGE =
+	'Value must be a hex string with 64 characters. Alternatively, main, test and beta can be used.';
+
 const writeConfigToFile = newConfig => {
 	try {
 		writeJSONSync(configFilePath, newConfig);
@@ -105,16 +108,12 @@ const setNethash = (dotNotation, value) => {
 		!Object.keys(NETHASHES).includes(value)
 	) {
 		if (value.length !== 64) {
-			throw new ValidationError(
-				'Value must be a hex string with 64 characters.',
-			);
+			throw new ValidationError(NETHASH_ERROR_MESSAGE);
 		}
 		try {
 			lisk.cryptography.hexToBuffer(value, 'utf8');
 		} catch (error) {
-			throw new ValidationError(
-				'Value must be a hex string with 64 characters.',
-			);
+			throw new ValidationError(NETHASH_ERROR_MESSAGE);
 		}
 	}
 	return setString(dotNotation, value);

--- a/src/commands/set.js
+++ b/src/commands/set.js
@@ -33,7 +33,7 @@ const WRITE_FAIL_WARNING =
 	'Config file could not be written: your changes will not be persisted.';
 
 const NETHASH_ERROR_MESSAGE =
-	'Value must be a hex string with 64 characters. Alternatively, main, test and beta can be used.';
+	'Value must be a hex string with 64 characters, or one of main, test or beta.';
 
 const writeConfigToFile = newConfig => {
 	try {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -15,15 +15,21 @@
  */
 import lisk from 'lisk-js';
 import config from './config';
+import { NETHASHES } from './constants';
 
-const { APIClient } = lisk;
+const { APIClient, constants } = lisk;
 
-const getAPIClient = testnet => {
-	const testnetOverrideValue =
-		typeof testnet === 'boolean' ? testnet : config.api.testnet;
-	return testnetOverrideValue === true
-		? APIClient.createTestnetAPIClient(config.api)
-		: APIClient.createMainnetAPIClient(config.api);
+const addresses = {
+	main: constants.MAINNET_NODES,
+	test: constants.TESTNET_NODES,
+	beta: constants.BETANET_NODES,
+};
+
+const getAPIClient = () => {
+	const { node, network } = config.api;
+	const nethash = NETHASHES[network] || network;
+	const nodes = node ? [node] : addresses[network];
+	return new APIClient(nodes, nethash);
 };
 
 export default getAPIClient;

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -19,7 +19,7 @@ import { NETHASHES } from './constants';
 
 const { APIClient, constants } = lisk;
 
-const addresses = {
+const seedNodes = {
 	main: constants.MAINNET_NODES,
 	test: constants.TESTNET_NODES,
 	beta: constants.BETANET_NODES,
@@ -28,7 +28,7 @@ const addresses = {
 const getAPIClient = () => {
 	const { node, network } = config.api;
 	const nethash = NETHASHES[network] || network;
-	const nodes = node ? [node] : addresses[network];
+	const nodes = node ? [node] : seedNodes[network];
 	return new APIClient(nodes, nethash);
 };
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -13,6 +13,10 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import lisk from 'lisk-js';
+
+const { constants } = lisk;
+
 export const COMMAND_TYPES = [
 	'accounts',
 	'addresses',
@@ -38,8 +42,14 @@ export const QUERY_INPUT_MAP = {
 
 export const CONFIG_VARIABLES = [
 	'api.node',
-	'api.testnet',
+	'api.network',
 	'json',
 	'name',
 	'pretty',
 ];
+
+export const NETHASHES = {
+	main: constants.MAINNET_NETHASH,
+	test: constants.TESTNET_NETHASH,
+	beta: constants.BETANET_NETHASH,
+};

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -52,13 +52,6 @@ const prettyDescription =
 const tableDescription =
 	'Prints output in table format (default). You can change the default behaviour in your config.json file.';
 
-const testnetDescription = `Specifies whether to run the command against the testnet. You can change the default behaviour in your config.json file.
-
-	Examples:
-	- --testnet (runs against testnet)
-	- --testnet false (runs against mainnet)
-`;
-
 const votesDescription = `Specifies the public keys for the delegate candidates you want to vote for. Takes either a string of public keys separated by commas, or a path to a file which contains the public keys.
 
 	Examples:
@@ -88,7 +81,6 @@ const options = {
 	password: ['-w, --password <source>', passwordDescription],
 	pretty: ['--pretty', prettyDescription],
 	table: ['-t, --table', tableDescription],
-	testnet: ['--testnet', testnetDescription],
 	unvotes: ['--unvotes <source...>', unvotesDescription],
 	votes: ['--votes <source...>', votesDescription],
 };

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -15,9 +15,9 @@
  */
 import getAPIClient from './api';
 
-export default (endpoint, parameters, { testnet } = {}) =>
+export default (endpoint, parameters) =>
 	// prettier-ignore
-	getAPIClient(testnet)[endpoint].get(parameters)
+	getAPIClient()[endpoint].get(parameters)
 		.then(res => {
 			if (res.data) {
 				if (Array.isArray(res.data)) {

--- a/test/specs/commands/set.js
+++ b/test/specs/commands/set.js
@@ -609,7 +609,7 @@ describe('set command', () => {
 									when.theActionIsCalledWithTheVariableAndTheValue,
 									() => {
 										Then(
-											'it should reject with validation error and message "Value must be a hex string with 64 characters. Alternatively, main, test and beta can be used."',
+											'it should reject with validation error and message "Value must be a hex string with 64 characters, or one of main, test or beta."',
 											then.itShouldRejectWithValidationErrorAndMessage,
 										);
 									},
@@ -624,7 +624,7 @@ describe('set command', () => {
 										when.theActionIsCalledWithTheVariableAndTheValue,
 										() => {
 											Then(
-												'it should reject with validation error and message "Value must be a hex string with 64 characters. Alternatively, main, test and beta can be used."',
+												'it should reject with validation error and message "Value must be a hex string with 64 characters, or one of main, test or beta."',
 												then.itShouldRejectWithValidationErrorAndMessage,
 											);
 										},
@@ -640,7 +640,7 @@ describe('set command', () => {
 										when.theActionIsCalledWithTheVariableAndTheValue,
 										() => {
 											Then(
-												'it should reject with validation error and message "Value must be a hex string with 64 characters. Alternatively, main, test and beta can be used."',
+												'it should reject with validation error and message "Value must be a hex string with 64 characters, or one of main, test or beta."',
 												then.itShouldRejectWithValidationErrorAndMessage,
 											);
 										},

--- a/test/specs/commands/set.js
+++ b/test/specs/commands/set.js
@@ -602,66 +602,52 @@ describe('set command', () => {
 								);
 							});
 						});
-						Given('a variable "api.testnet"', given.aVariable, () => {
+						Given('a variable "api.network"', given.aVariable, () => {
 							Given('an unknown value "xxx"', given.anUnknownValue, () => {
 								When(
 									'the action is called with the variable and the value',
 									when.theActionIsCalledWithTheVariableAndTheValue,
 									() => {
 										Then(
-											'it should reject with validation error and message "Value must be a boolean."',
+											'it should reject with validation error and message "Value must be a hex string with 64 characters."',
 											then.itShouldRejectWithValidationErrorAndMessage,
 										);
 									},
 								);
 							});
-							Given('a value "true"', given.aValue, () => {
-								Given(
-									'the config file cannot be written',
-									given.theConfigFileCannotBeWritten,
-									() => {
-										Given(
-											'Vorpal is in non-interactive mode',
-											given.vorpalIsInNonInteractiveMode,
-											() => {
-												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
-													() => {
-														Then(
-															'it should reject with file system error and message "Config file could not be written: your changes will not be persisted."',
-															then.itShouldRejectWithFileSystemErrorAndMessage,
-														);
-													},
-												);
-											},
-										);
-										Given(
-											'Vorpal is in interactive mode',
-											given.vorpalIsInInteractiveMode,
-											() => {
-												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
-													() => {
-														Then(
-															'it should update the config nested variable "api.testnet" to boolean true',
-															then.itShouldUpdateTheConfigNestedVariableToBoolean,
-														);
-														Then(
-															'it should resolve to an object with warning "Config file could not be written: your changes will not be persisted."',
-															then.itShouldResolveToAnObjectWithWarning,
-														);
-														Then(
-															'it should resolve to an object with message "Successfully set api.testnet to true."',
-															then.itShouldResolveToAnObjectWithMessage,
-														);
-													},
-												);
-											},
-										);
-									},
-								);
+							Given(
+								'a value "ed14889723f24ecc54871d058d98ce91ff2f97"',
+								given.aValue,
+								() => {
+									When(
+										'the action is called with the variable and the value',
+										when.theActionIsCalledWithTheVariableAndTheValue,
+										() => {
+											Then(
+												'it should reject with validation error and message "Value must be a hex string with 64 characters."',
+												then.itShouldRejectWithValidationErrorAndMessage,
+											);
+										},
+									);
+								},
+							);
+							Given(
+								'a value "ed14889723f24ecc54871d058xxxxxxxxxxxxxxxxxxxxxxxxxba2b7b70ad2500"',
+								given.aValue,
+								() => {
+									When(
+										'the action is called with the variable and the value',
+										when.theActionIsCalledWithTheVariableAndTheValue,
+										() => {
+											Then(
+												'it should reject with validation error and message "Value must be a hex string with 64 characters."',
+												then.itShouldRejectWithValidationErrorAndMessage,
+											);
+										},
+									);
+								},
+							);
+							Given('a value "main"', given.aValue, () => {
 								Given(
 									'the config file can be written',
 									given.theConfigFileCanBeWritten,
@@ -675,15 +661,15 @@ describe('set command', () => {
 													when.theActionIsCalledWithTheVariableAndTheValue,
 													() => {
 														Then(
-															'it should update the config nested variable "api.testnet" to boolean true',
-															then.itShouldUpdateTheConfigNestedVariableToBoolean,
+															'it should update the config nested variable "api.network" to the value',
+															then.itShouldUpdateTheConfigNestedVariableToTheValue,
 														);
 														Then(
 															'it should write the updated config to the config file',
 															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
 														);
 														Then(
-															'it should resolve to an object with message "Successfully set api.testnet to true."',
+															'it should resolve to an object with message "Successfully set api.network to main."',
 															then.itShouldResolveToAnObjectWithMessage,
 														);
 													},
@@ -699,15 +685,15 @@ describe('set command', () => {
 													when.theActionIsCalledWithTheVariableAndTheValue,
 													() => {
 														Then(
-															'it should update the config nested variable "api.testnet" to boolean true',
-															then.itShouldUpdateTheConfigNestedVariableToBoolean,
+															'it should update the config nested variable "api.network" to the value',
+															then.itShouldUpdateTheConfigNestedVariableToTheValue,
 														);
 														Then(
 															'it should write the updated config to the config file',
 															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
 														);
 														Then(
-															'it should resolve to an object with message "Successfully set api.testnet to true."',
+															'it should resolve to an object with message "Successfully set api.network to main."',
 															then.itShouldResolveToAnObjectWithMessage,
 														);
 													},
@@ -717,53 +703,7 @@ describe('set command', () => {
 									},
 								);
 							});
-							Given('a value "false"', given.aValue, () => {
-								Given(
-									'the config file cannot be written',
-									given.theConfigFileCannotBeWritten,
-									() => {
-										Given(
-											'Vorpal is in non-interactive mode',
-											given.vorpalIsInNonInteractiveMode,
-											() => {
-												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
-													() => {
-														Then(
-															'it should reject with file system error and message "Config file could not be written: your changes will not be persisted."',
-															then.itShouldRejectWithFileSystemErrorAndMessage,
-														);
-													},
-												);
-											},
-										);
-										Given(
-											'Vorpal is in interactive mode',
-											given.vorpalIsInInteractiveMode,
-											() => {
-												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
-													() => {
-														Then(
-															'it should update the config nested variable "api.testnet" to boolean false',
-															then.itShouldUpdateTheConfigNestedVariableToBoolean,
-														);
-														Then(
-															'it should resolve to an object with warning "Config file could not be written: your changes will not be persisted."',
-															then.itShouldResolveToAnObjectWithWarning,
-														);
-														Then(
-															'it should resolve to an object with message "Successfully set api.testnet to false."',
-															then.itShouldResolveToAnObjectWithMessage,
-														);
-													},
-												);
-											},
-										);
-									},
-								);
+							Given('a value "test"', given.aValue, () => {
 								Given(
 									'the config file can be written',
 									given.theConfigFileCanBeWritten,
@@ -777,15 +717,15 @@ describe('set command', () => {
 													when.theActionIsCalledWithTheVariableAndTheValue,
 													() => {
 														Then(
-															'it should update the config nested variable "api.testnet" to boolean false',
-															then.itShouldUpdateTheConfigNestedVariableToBoolean,
+															'it should update the config nested variable "api.network" to the value',
+															then.itShouldUpdateTheConfigNestedVariableToTheValue,
 														);
 														Then(
 															'it should write the updated config to the config file',
 															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
 														);
 														Then(
-															'it should resolve to an object with message "Successfully set api.testnet to false."',
+															'it should resolve to an object with message "Successfully set api.network to test."',
 															then.itShouldResolveToAnObjectWithMessage,
 														);
 													},
@@ -801,15 +741,15 @@ describe('set command', () => {
 													when.theActionIsCalledWithTheVariableAndTheValue,
 													() => {
 														Then(
-															'it should update the config nested variable "api.testnet" to boolean false',
-															then.itShouldUpdateTheConfigNestedVariableToBoolean,
+															'it should update the config nested variable "api.network" to the value',
+															then.itShouldUpdateTheConfigNestedVariableToTheValue,
 														);
 														Then(
 															'it should write the updated config to the config file',
 															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
 														);
 														Then(
-															'it should resolve to an object with message "Successfully set api.testnet to false."',
+															'it should resolve to an object with message "Successfully set api.network to test."',
 															then.itShouldResolveToAnObjectWithMessage,
 														);
 													},
@@ -819,6 +759,168 @@ describe('set command', () => {
 									},
 								);
 							});
+							Given('a value "beta"', given.aValue, () => {
+								Given(
+									'the config file can be written',
+									given.theConfigFileCanBeWritten,
+									() => {
+										Given(
+											'Vorpal is in non-interactive mode',
+											given.vorpalIsInNonInteractiveMode,
+											() => {
+												When(
+													'the action is called with the variable and the value',
+													when.theActionIsCalledWithTheVariableAndTheValue,
+													() => {
+														Then(
+															'it should update the config nested variable "api.network" to the value',
+															then.itShouldUpdateTheConfigNestedVariableToTheValue,
+														);
+														Then(
+															'it should write the updated config to the config file',
+															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+														);
+														Then(
+															'it should resolve to an object with message "Successfully set api.network to beta."',
+															then.itShouldResolveToAnObjectWithMessage,
+														);
+													},
+												);
+											},
+										);
+										Given(
+											'Vorpal is in interactive mode',
+											given.vorpalIsInInteractiveMode,
+											() => {
+												When(
+													'the action is called with the variable and the value',
+													when.theActionIsCalledWithTheVariableAndTheValue,
+													() => {
+														Then(
+															'it should update the config nested variable "api.network" to the value',
+															then.itShouldUpdateTheConfigNestedVariableToTheValue,
+														);
+														Then(
+															'it should write the updated config to the config file',
+															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+														);
+														Then(
+															'it should resolve to an object with message "Successfully set api.network to beta."',
+															then.itShouldResolveToAnObjectWithMessage,
+														);
+													},
+												);
+											},
+										);
+									},
+								);
+							});
+							Given(
+								'a value "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2500"',
+								given.aValue,
+								() => {
+									Given(
+										'the config file cannot be written',
+										given.theConfigFileCannotBeWritten,
+										() => {
+											Given(
+												'Vorpal is in non-interactive mode',
+												given.vorpalIsInNonInteractiveMode,
+												() => {
+													When(
+														'the action is called with the variable and the value',
+														when.theActionIsCalledWithTheVariableAndTheValue,
+														() => {
+															Then(
+																'it should reject with file system error and message "Config file could not be written: your changes will not be persisted."',
+																then.itShouldRejectWithFileSystemErrorAndMessage,
+															);
+														},
+													);
+												},
+											);
+											Given(
+												'Vorpal is in interactive mode',
+												given.vorpalIsInInteractiveMode,
+												() => {
+													When(
+														'the action is called with the variable and the value',
+														when.theActionIsCalledWithTheVariableAndTheValue,
+														() => {
+															Then(
+																'it should update the config nested variable "api.network" to the value',
+																then.itShouldUpdateTheConfigNestedVariableToTheValue,
+															);
+															Then(
+																'it should resolve to an object with warning "Config file could not be written: your changes will not be persisted."',
+																then.itShouldResolveToAnObjectWithWarning,
+															);
+															Then(
+																'it should resolve to an object with message "Successfully set api.network to ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2500."',
+																then.itShouldResolveToAnObjectWithMessage,
+															);
+														},
+													);
+												},
+											);
+										},
+									);
+									Given(
+										'the config file can be written',
+										given.theConfigFileCanBeWritten,
+										() => {
+											Given(
+												'Vorpal is in non-interactive mode',
+												given.vorpalIsInNonInteractiveMode,
+												() => {
+													When(
+														'the action is called with the variable and the value',
+														when.theActionIsCalledWithTheVariableAndTheValue,
+														() => {
+															Then(
+																'it should update the config nested variable "api.network" to the value',
+																then.itShouldUpdateTheConfigNestedVariableToTheValue,
+															);
+															Then(
+																'it should write the updated config to the config file',
+																then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															);
+															Then(
+																'it should resolve to an object with message "Successfully set api.network to ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2500."',
+																then.itShouldResolveToAnObjectWithMessage,
+															);
+														},
+													);
+												},
+											);
+											Given(
+												'Vorpal is in interactive mode',
+												given.vorpalIsInInteractiveMode,
+												() => {
+													When(
+														'the action is called with the variable and the value',
+														when.theActionIsCalledWithTheVariableAndTheValue,
+														() => {
+															Then(
+																'it should update the config nested variable "api.network" to the value',
+																then.itShouldUpdateTheConfigNestedVariableToTheValue,
+															);
+															Then(
+																'it should write the updated config to the config file',
+																then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															);
+															Then(
+																'it should resolve to an object with message "Successfully set api.network to ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2500."',
+																then.itShouldResolveToAnObjectWithMessage,
+															);
+														},
+													);
+												},
+											);
+										},
+									);
+								},
+							);
 						});
 					});
 				});

--- a/test/specs/commands/set.js
+++ b/test/specs/commands/set.js
@@ -609,7 +609,7 @@ describe('set command', () => {
 									when.theActionIsCalledWithTheVariableAndTheValue,
 									() => {
 										Then(
-											'it should reject with validation error and message "Value must be a hex string with 64 characters."',
+											'it should reject with validation error and message "Value must be a hex string with 64 characters. Alternatively, main, test and beta can be used."',
 											then.itShouldRejectWithValidationErrorAndMessage,
 										);
 									},
@@ -624,7 +624,7 @@ describe('set command', () => {
 										when.theActionIsCalledWithTheVariableAndTheValue,
 										() => {
 											Then(
-												'it should reject with validation error and message "Value must be a hex string with 64 characters."',
+												'it should reject with validation error and message "Value must be a hex string with 64 characters. Alternatively, main, test and beta can be used."',
 												then.itShouldRejectWithValidationErrorAndMessage,
 											);
 										},
@@ -640,7 +640,7 @@ describe('set command', () => {
 										when.theActionIsCalledWithTheVariableAndTheValue,
 										() => {
 											Then(
-												'it should reject with validation error and message "Value must be a hex string with 64 characters."',
+												'it should reject with validation error and message "Value must be a hex string with 64 characters. Alternatively, main, test and beta can be used."',
 												then.itShouldRejectWithValidationErrorAndMessage,
 											);
 										},
@@ -816,7 +816,7 @@ describe('set command', () => {
 								);
 							});
 							Given(
-								'a value "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2500"',
+								'a value "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"',
 								given.aValue,
 								() => {
 									Given(
@@ -856,7 +856,7 @@ describe('set command', () => {
 																then.itShouldResolveToAnObjectWithWarning,
 															);
 															Then(
-																'it should resolve to an object with message "Successfully set api.network to ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2500."',
+																'it should resolve to an object with message "Successfully set api.network to aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa."',
 																then.itShouldResolveToAnObjectWithMessage,
 															);
 														},
@@ -886,7 +886,7 @@ describe('set command', () => {
 																then.itShouldWriteTheUpdatedConfigToTheConfigFile,
 															);
 															Then(
-																'it should resolve to an object with message "Successfully set api.network to ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2500."',
+																'it should resolve to an object with message "Successfully set api.network to aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa."',
 																then.itShouldResolveToAnObjectWithMessage,
 															);
 														},
@@ -910,7 +910,7 @@ describe('set command', () => {
 																then.itShouldWriteTheUpdatedConfigToTheConfigFile,
 															);
 															Then(
-																'it should resolve to an object with message "Successfully set api.network to ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2500."',
+																'it should resolve to an object with message "Successfully set api.network to aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa."',
 																then.itShouldResolveToAnObjectWithMessage,
 															);
 														},

--- a/test/specs/utils/api.js
+++ b/test/specs/utils/api.js
@@ -19,84 +19,116 @@ import * as then from '../../steps/3_then';
 
 describe('API util', () => {
 	Given(
-		'a config with "api.testnet" set to true',
-		given.aConfigWithAPITestnetSetTo,
+		'a config with "api.network" set to "main"',
+		given.aConfigWithAPINetworkSetTo,
 		() => {
-			When(
-				'a API Client instance is created',
-				when.aLiskAPIInstanceIsCreated,
+			Given(
+				'a config with "api.node" set to "http://localhost:4000"',
+				given.aConfigWithAPINodeSetTo,
 				() => {
-					Then(
-						'the lisk instance should be a lisk-js API instance',
-						then.theLiskAPIInstanceShouldBeALiskJSAPIInstance,
-					);
-					Then(
-						'the lisk instance should have nethash equal to "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba"',
-						then.theLiskAPIInstanceShouldHaveNethashEqualTo,
+					When(
+						'a API Client instance is created',
+						when.aLiskAPIInstanceIsCreated,
+						() => {
+							Then(
+								'the lisk instance should be a lisk-js API instance',
+								then.theLiskAPIInstanceShouldBeALiskJSAPIInstance,
+							);
+							Then(
+								'the lisk instance should have nethash equal to "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511"',
+								then.theLiskAPIInstanceShouldHaveNethashEqualTo,
+							);
+							Then(
+								'the lisk instance should have nethash equal to "http://localhost:4000"',
+								then.theLiskAPIInstanceShouldHaveCurrentNodeEqualTo,
+							);
+						},
 					);
 				},
 			);
 		},
 	);
 	Given(
-		'a config with "api.testnet" set to false',
-		given.aConfigWithAPITestnetSetTo,
+		'a config with "api.network" set to "test"',
+		given.aConfigWithAPINetworkSetTo,
 		() => {
-			When(
-				'a API Client instance is created',
-				when.aLiskAPIInstanceIsCreated,
+			Given(
+				'a config with "api.node" set to "http://localhost:4000"',
+				given.aConfigWithAPINodeSetTo,
 				() => {
-					Then(
-						'the lisk instance should be a lisk-js API instance',
-						then.theLiskAPIInstanceShouldBeALiskJSAPIInstance,
-					);
-					Then(
-						'the lisk instance should have nethash equal to "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511"',
-						then.theLiskAPIInstanceShouldHaveNethashEqualTo,
+					When(
+						'a API Client instance is created',
+						when.aLiskAPIInstanceIsCreated,
+						() => {
+							Then(
+								'the lisk instance should be a lisk-js API instance',
+								then.theLiskAPIInstanceShouldBeALiskJSAPIInstance,
+							);
+							Then(
+								'the lisk instance should have nethash equal to "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba"',
+								then.theLiskAPIInstanceShouldHaveNethashEqualTo,
+							);
+							Then(
+								'the lisk instance should have nethash equal to "http://localhost:4000"',
+								then.theLiskAPIInstanceShouldHaveCurrentNodeEqualTo,
+							);
+						},
 					);
 				},
 			);
-			When(
-				'a API Client instance is created with an input of "notboolean"',
-				when.aLiskAPIInstanceIsCreatedWithAnInputOf,
+			Given(
+				'a config with "api.node" set to ""',
+				given.aConfigWithAPINodeSetTo,
 				() => {
-					Then(
-						'the lisk instance should be a lisk-js API instance',
-						then.theLiskAPIInstanceShouldBeALiskJSAPIInstance,
-					);
-					Then(
-						'the lisk instance should have nethash equal to "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511"',
-						then.theLiskAPIInstanceShouldHaveNethashEqualTo,
+					When(
+						'a API Client instance is created',
+						when.aLiskAPIInstanceIsCreated,
+						() => {
+							Then(
+								'the lisk instance should be a lisk-js API instance',
+								then.theLiskAPIInstanceShouldBeALiskJSAPIInstance,
+							);
+							Then(
+								'the lisk instance should have nethash equal to "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba"',
+								then.theLiskAPIInstanceShouldHaveNethashEqualTo,
+							);
+							Then(
+								'the lisk instance should have nethash equal to "http://testnet.lisk.io:7000"',
+								then.theLiskAPIInstanceShouldHaveCurrentNodeEqualTo,
+							);
+						},
 					);
 				},
 			);
 		},
 	);
-	When(
-		'a Lisk API Client instance is created with an input boolean of "true"',
-		when.aLiskAPIInstanceIsCreatedWithAnInputBooleanOf,
+	Given(
+		'a config with "api.network" set to "ef3844327d1fd0fc5aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2b7e859e9ca0c"',
+		given.aConfigWithAPINetworkSetTo,
 		() => {
-			Then(
-				'the lisk instance should be a lisk-js API instance',
-				then.theLiskAPIInstanceShouldBeALiskJSAPIInstance,
-			);
-			Then(
-				'the lisk instance should have nethash equal to "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba"',
-				then.theLiskAPIInstanceShouldHaveNethashEqualTo,
-			);
-		},
-	);
-	When(
-		'a Lisk API Client instance is created with an input boolean of "false"',
-		when.aLiskAPIInstanceIsCreatedWithAnInputBooleanOf,
-		() => {
-			Then(
-				'the lisk instance should be a lisk-js API instance',
-				then.theLiskAPIInstanceShouldBeALiskJSAPIInstance,
-			);
-			Then(
-				'the lisk instance should have nethash equal to "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511"',
-				then.theLiskAPIInstanceShouldHaveNethashEqualTo,
+			Given(
+				'a config with "api.node" set to "http://localhost:4000"',
+				given.aConfigWithAPINodeSetTo,
+				() => {
+					When(
+						'a API Client instance is created',
+						when.aLiskAPIInstanceIsCreated,
+						() => {
+							Then(
+								'the lisk instance should be a lisk-js API instance',
+								then.theLiskAPIInstanceShouldBeALiskJSAPIInstance,
+							);
+							Then(
+								'the lisk instance should have nethash equal to "ef3844327d1fd0fc5aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2b7e859e9ca0c"',
+								then.theLiskAPIInstanceShouldHaveNethashEqualTo,
+							);
+							Then(
+								'the lisk instance should have nethash equal to "http://localhost:4000"',
+								then.theLiskAPIInstanceShouldHaveCurrentNodeEqualTo,
+							);
+						},
+					);
+				},
 			);
 		},
 	);

--- a/test/specs/utils/query.js
+++ b/test/specs/utils/query.js
@@ -45,81 +45,53 @@ describe('Query function', () => {
 								);
 							},
 						);
-						Given(
-							'an options object with key "testnet" set to boolean "true"',
-							given.anOptionsObjectWithKeySetToBoolean,
+						When(
+							'the query instance sends a request and the lisk api instance resolves with a successful object data response',
+							when.theQueryInstanceSendsARequestAndTheLiskAPIInstanceResolvesWithASuccessfulObjectDataResponse,
 							() => {
-								When(
-									'the query instance sends a request and the lisk api instance resolves with a successful array data response',
-									when.theQueryInstanceSendsARequestAndTheLiskAPIInstanceResolvesWithASuccessfulArrayDataResponse,
-									() => {
-										Then(
-											'it should resolve to an object',
-											then.itShouldResolveToAnObject,
-										);
-										Then(
-											'it should resolve to the first element of data of the response',
-											then.itShouldResolveToTheFirstElementOfDataOfTheResponse,
-										);
-										Then(
-											'it should use the lisk api instance to send a request to the endpoint using the parameters',
-											then.itShouldUseTheLiskAPIInstanceToSendARequestToTheEndpointUsingTheParameters,
-										);
-										Then(
-											'the "getAPIClient" should be called with the testnet option',
-											then.theGetAPIClientShouldBeCalledWithTestnetOption,
-										);
-									},
+								Then(
+									'it should resolve to an object',
+									then.itShouldResolveToAnObject,
 								);
-								When(
-									'the query instance sends a request and the lisk api instance resolves with a successful object data response',
-									when.theQueryInstanceSendsARequestAndTheLiskAPIInstanceResolvesWithASuccessfulObjectDataResponse,
-									() => {
-										Then(
-											'it should resolve to an object',
-											then.itShouldResolveToAnObject,
-										);
-										Then(
-											'it should resolve to the data of the response',
-											then.itShouldResolveToTheDataOfTheResponse,
-										);
-										Then(
-											'it should use the lisk api instance to send a request to the endpoint using the parameters',
-											then.itShouldUseTheLiskAPIInstanceToSendARequestToTheEndpointUsingTheParameters,
-										);
-										Then(
-											'the "getAPIClient" should be called with the testnet option',
-											then.theGetAPIClientShouldBeCalledWithTestnetOption,
-										);
-									},
+								Then(
+									'it should resolve to the data of the response',
+									then.itShouldResolveToTheDataOfTheResponse,
 								);
-								When(
-									'the query instance sends a request and the lisk api instance resolves with a failed response',
-									when.theQueryInstanceSendsARequestAndTheLiskAPIInstanceResolvesWithAFailedResponse,
-									() => {
-										Then(
-											'it should use the lisk api instance to send a request to the endpoint using the parameters',
-											then.itShouldUseTheLiskAPIInstanceToSendARequestToTheEndpointUsingTheParameters,
-										);
-										Then(
-											'it should reject with the error and message "No data was returned."',
-											then.itShouldRejectWithErrorAndMessage,
-										);
-									},
+								Then(
+									'it should use the lisk api instance to send a request to the endpoint using the parameters',
+									then.itShouldUseTheLiskAPIInstanceToSendARequestToTheEndpointUsingTheParameters,
 								);
-								When(
-									'the query instance sends a request and the lisk api instance resolves with a successful response of empty array',
-									when.theQueryInstanceSendsARequestAndTheLiskAPIInstanceResolvesWithASuccessfulEmptyArrayDataResponse,
-									() => {
-										Then(
-											'it should use the lisk api instance to send a request to the endpoint using the parameters',
-											then.itShouldUseTheLiskAPIInstanceToSendARequestToTheEndpointUsingTheParameters,
-										);
-										Then(
-											'it should reject with the error and message "No accounts found using specified parameters."',
-											then.itShouldRejectWithErrorAndMessage,
-										);
-									},
+								Then(
+									'the "getAPIClient" should be called',
+									then.theGetAPIClientShouldBeCalled,
+								);
+							},
+						);
+						When(
+							'the query instance sends a request and the lisk api instance resolves with a failed response',
+							when.theQueryInstanceSendsARequestAndTheLiskAPIInstanceResolvesWithAFailedResponse,
+							() => {
+								Then(
+									'it should use the lisk api instance to send a request to the endpoint using the parameters',
+									then.itShouldUseTheLiskAPIInstanceToSendARequestToTheEndpointUsingTheParameters,
+								);
+								Then(
+									'it should reject with the error and message "No data was returned."',
+									then.itShouldRejectWithErrorAndMessage,
+								);
+							},
+						);
+						When(
+							'the query instance sends a request and the lisk api instance resolves with a successful response of empty array',
+							when.theQueryInstanceSendsARequestAndTheLiskAPIInstanceResolvesWithASuccessfulEmptyArrayDataResponse,
+							() => {
+								Then(
+									'it should use the lisk api instance to send a request to the endpoint using the parameters',
+									then.itShouldUseTheLiskAPIInstanceToSendARequestToTheEndpointUsingTheParameters,
+								);
+								Then(
+									'it should reject with the error and message "No accounts found using specified parameters."',
+									then.itShouldRejectWithErrorAndMessage,
 								);
 							},
 						);

--- a/test/steps/api/3_then.js
+++ b/test/steps/api/3_then.js
@@ -58,13 +58,18 @@ export function theLiskAPIInstanceShouldBeALiskJSAPIInstance() {
 	return expect(liskAPIInstance).to.be.instanceOf(lisk.APIClient);
 }
 
+export function theGetAPIClientShouldBeCalled() {
+	return expect(getAPIClient).to.be.called;
+}
+
 export function theLiskAPIInstanceShouldHaveNethashEqualTo() {
 	const { liskAPIInstance } = this.test.ctx;
 	const nethash = getFirstQuotedString(this.test.title);
 	return expect(liskAPIInstance.headers.nethash).to.equal(nethash);
 }
 
-export function theGetAPIClientShouldBeCalledWithTestnetOption() {
-	const { options } = this.test.ctx;
-	return expect(getAPIClient).to.be.calledWithExactly(options.testnet);
+export function theLiskAPIInstanceShouldHaveCurrentNodeEqualTo() {
+	const { liskAPIInstance } = this.test.ctx;
+	const node = getFirstQuotedString(this.test.title);
+	return expect(liskAPIInstance.currentNode).to.equal(node);
 }

--- a/test/steps/config/1_given.js
+++ b/test/steps/config/1_given.js
@@ -16,7 +16,7 @@
 import lockfile from 'lockfile';
 import defaultConfig from '../../../default_config.json';
 import * as currentConfig from '../../../src/utils/config';
-import { getFirstBoolean, getBooleans } from '../utils';
+import { getFirstBoolean, getBooleans, getQuotedStrings } from '../utils';
 
 export function aConfigWithUnknownProperties() {
 	const config = {
@@ -53,9 +53,21 @@ export function aConfigWithJsonSetTo() {
 	this.test.ctx.config = config;
 }
 
-export function aConfigWithAPITestnetSetTo() {
-	const testnet = getFirstBoolean(this.test.parent.title);
-	const config = { api: { testnet } };
+export function aConfigWithAPINodeSetTo() {
+	const node = getQuotedStrings(this.test.parent.title)[1];
+	const { api } = currentConfig.default || {};
+	api.node = node;
+	const config = { api };
+
+	currentConfig.default = config;
+	this.test.ctx.config = config;
+}
+
+export function aConfigWithAPINetworkSetTo() {
+	const network = getQuotedStrings(this.test.parent.title)[1];
+	const { api } = currentConfig.default || {};
+	api.network = network;
+	const config = { api };
 
 	currentConfig.default = config;
 	this.test.ctx.config = config;

--- a/test/steps/config/3_then.js
+++ b/test/steps/config/3_then.js
@@ -24,15 +24,14 @@ export function itShouldUpdateTheConfigVariableToTheValue() {
 		.equal(value);
 }
 
-export function itShouldUpdateTheConfigNestedVariableToBoolean() {
-	const { config } = this.test.ctx;
+export function itShouldUpdateTheConfigNestedVariableToTheValue() {
+	const { value, config } = this.test.ctx;
 	const nestedVariable = getFirstQuotedString(this.test.title).split('.');
-	const boolean = getFirstBoolean(this.test.title);
-	const value = nestedVariable.reduce(
+	const configValue = nestedVariable.reduce(
 		(currentObject, nextKey) => currentObject[nextKey],
 		config,
 	);
-	return expect(value).to.equal(boolean);
+	return expect(configValue).to.equal(value);
 }
 
 export function itShouldUpdateTheConfigVariableToBoolean() {


### PR DESCRIPTION
### What was the problem?
In order to support beta net option, we needed to add an option to set the network, instead of boolean testnet option.

### How did I fix it?
- Add `api.network` option to config
- Remove `testnet` options

### How to test it?
```
set api.network beta
get delegate genesis_1
```

### Review checklist

* The PR solves #477 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
