### PR TITLE
Fix tablify of nested object - Closes #475

### DIFF
--- a/src/utils/tablify.js
+++ b/src/utils/tablify.js
@@ -35,7 +35,9 @@ const chars = {
 };
 
 const getNestedValue = data => keyString =>
-	keyString.split('.').reduce((accumulated, key) => accumulated[key], data);
+	keyString
+		.split('.')
+		.reduce((accumulated, key) => (accumulated ? accumulated[key] : ''), data);
 
 const addValuesToTable = (table, data) => {
 	const nestedValues = table.options.head.map(getNestedValue(data));

--- a/src/utils/tablify.js
+++ b/src/utils/tablify.js
@@ -35,7 +35,7 @@ const chars = {
 };
 
 const getNestedValue = data => keyString =>
-	keyString.split('.').reduce((obj, key) => obj[key], data);
+	keyString.split('.').reduce((accumulated, key) => accumulated[key], data);
 
 const addValuesToTable = (table, data) => {
 	const nestedValues = table.options.head.map(getNestedValue(data));
@@ -43,16 +43,6 @@ const addValuesToTable = (table, data) => {
 		value => (Array.isArray(value) ? value.join('\n') : value),
 	);
 	return valuesToPush.length && table.push(valuesToPush);
-};
-
-const reduceKeys = (keys, row) => {
-	const newKeys = Object.keys(row).filter(
-		key =>
-			!keys.includes(key) &&
-			row[key] !== undefined &&
-			!(row[key] instanceof Error),
-	);
-	return keys.concat(newKeys);
 };
 
 const getKeys = (data, limit = 3, loop = 1) => {
@@ -81,6 +71,21 @@ const getKeys = (data, limit = 3, loop = 1) => {
 			],
 			[],
 		);
+};
+
+const reduceKeys = (keys, row) => {
+	const newKeys = Object.entries(row).flatMap(([key, value]) => {
+		if (keys.includes(key) || value === undefined || value instanceof Error) {
+			return [];
+		}
+		if (typeof value === 'object') {
+			return getKeys(value)
+				.map(nestedKey => `${key}.${nestedKey}`)
+				.filter(nestedKey => !keys.includes(nestedKey));
+		}
+		return key;
+	});
+	return keys.concat(newKeys);
 };
 
 const tablify = data => {

--- a/src/utils/tablify.js
+++ b/src/utils/tablify.js
@@ -80,7 +80,7 @@ const reduceKeys = (keys, row) => {
 		if (keys.includes(key) || value === undefined || value instanceof Error) {
 			return [];
 		}
-		if (typeof value === 'object') {
+		if (typeof value === 'object' && !Array.isArray(value)) {
 			return getKeys(value)
 				.map(nestedKey => `${key}.${nestedKey}`)
 				.filter(nestedKey => !keys.includes(nestedKey));

--- a/test/specs/utils/tablify.js
+++ b/test/specs/utils/tablify.js
@@ -102,4 +102,20 @@ describe('tablify util', () => {
 			});
 		},
 	);
+	Given(
+		'an array of objects with nested keys',
+		given.anArrayOfObjectsWithNestedKeys,
+		() => {
+			When('the array is tablified', when.theArrayIsTablified, () => {
+				Then(
+					'the returned table should have a head with the objects’ nested keys',
+					then.theReturnedTableShouldHaveAHeadWithTheObjectsNestedKeys,
+				);
+				Then(
+					'the returned table should have a row for each object with the object’s values',
+					then.theReturnedTableShouldHaveARowForEachObjectWithTheObjectNestedValues,
+				);
+			});
+		},
+	);
 });

--- a/test/steps/general/1_given.js
+++ b/test/steps/general/1_given.js
@@ -132,6 +132,38 @@ export function anArrayOfObjectsWithTheSameKeys() {
 	];
 }
 
+export function anArrayOfObjectsWithNestedKeys() {
+	this.test.ctx.testArray = [
+		{
+			lisk: 'js',
+			version: 1,
+			assets: {
+				type: 0,
+			},
+		},
+		{
+			lisk: 'ts',
+			version: 2,
+			assets: {
+				type: 1,
+			},
+		},
+		{
+			lisk: 'jsx',
+			version: 3,
+			assets: {
+				type: 3,
+			},
+		},
+	];
+	this.test.ctx.testArrayKeysResult = ['lisk', 'version', 'assets.type'];
+	this.test.ctx.testArrayValuesResult = [
+		['js', 1, 0],
+		['ts', 2, 1],
+		['jsx', 3, 3],
+	];
+}
+
 export function anArrayOfObjectsWithDivergentKeys() {
 	this.test.ctx.testArray = [
 		{

--- a/test/steps/general/1_given.js
+++ b/test/steps/general/1_given.js
@@ -144,6 +144,9 @@ export function anArrayOfObjectsWithNestedKeys() {
 		{
 			lisk: 'ts',
 			version: 2,
+			data: {
+				testing: 'test-string',
+			},
 			assets: {
 				type: 1,
 			},
@@ -156,11 +159,16 @@ export function anArrayOfObjectsWithNestedKeys() {
 			},
 		},
 	];
-	this.test.ctx.testArrayKeysResult = ['lisk', 'version', 'assets.type'];
+	this.test.ctx.testArrayKeysResult = [
+		'lisk',
+		'version',
+		'assets.type',
+		'data.testing',
+	];
 	this.test.ctx.testArrayValuesResult = [
-		['js', 1, 0],
-		['ts', 2, 1],
-		['jsx', 3, 3],
+		['js', 1, 0, ''],
+		['ts', 2, 1, 'test-string'],
+		['jsx', 3, 3, ''],
 	];
 }
 

--- a/test/steps/general/1_given.js
+++ b/test/steps/general/1_given.js
@@ -140,6 +140,7 @@ export function anArrayOfObjectsWithNestedKeys() {
 			assets: {
 				type: 0,
 			},
+			signatures: ['publicKey1', 'publicKey2'],
 		},
 		{
 			lisk: 'ts',
@@ -157,18 +158,20 @@ export function anArrayOfObjectsWithNestedKeys() {
 			assets: {
 				type: 3,
 			},
+			signatures: [],
 		},
 	];
 	this.test.ctx.testArrayKeysResult = [
 		'lisk',
 		'version',
 		'assets.type',
+		'signatures',
 		'data.testing',
 	];
 	this.test.ctx.testArrayValuesResult = [
-		['js', 1, 0, ''],
-		['ts', 2, 1, 'test-string'],
-		['jsx', 3, 3, ''],
+		['js', 1, 0, 'publicKey1\npublicKey2', ''],
+		['ts', 2, 1, undefined, 'test-string'],
+		['jsx', 3, 3, '', ''],
 	];
 }
 

--- a/test/steps/printing/3_then.js
+++ b/test/steps/printing/3_then.js
@@ -176,11 +176,25 @@ export function theReturnedTableShouldHaveAHeadWithTheObjectsKeys() {
 		.eql(keys);
 }
 
+export function theReturnedTableShouldHaveAHeadWithTheObjectsNestedKeys() {
+	const { returnValue, testArrayKeysResult } = this.test.ctx;
+	return expect(returnValue.options)
+		.to.have.property('head')
+		.eql(testArrayKeysResult);
+}
+
 export function theReturnedTableShouldHaveARowForEachObjectWithTheObjectValues() {
 	const { returnValue, testArray } = this.test.ctx;
 	return testArray.forEach((testObject, i) => {
 		const values = Object.values(testObject);
 		return expect(returnValue[i]).to.eql(values);
+	});
+}
+
+export function theReturnedTableShouldHaveARowForEachObjectWithTheObjectNestedValues() {
+	const { returnValue, testArray, testArrayValuesResult } = this.test.ctx;
+	return testArray.forEach((testObject, i) => {
+		return expect(returnValue[i]).to.eql(testArrayValuesResult[i]);
 	});
 }
 


### PR DESCRIPTION
### What was the problem?
When we want to display a nested object with tabilify, it doesn't show the nested key and value correctly.

### How did I fix it?
reuse the nestedValue lookup function, and get the header,
and go to find the nested value for the header.

### How to test it?
`list delegates genesis_5 genesis_1`

### Review checklist

* The PR solves #475 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
