### PR TITLE
Convert amount in transfer - Closes #482

### DIFF
--- a/src/commands/create_transaction_transfer.js
+++ b/src/commands/create_transaction_transfer.js
@@ -16,6 +16,7 @@
 import getInputsFromSources from '../utils/input';
 import {
 	createCommand,
+	normalizeAmount,
 	validateAddress,
 	validateAmount,
 } from '../utils/helpers';
@@ -47,7 +48,8 @@ export const actionCreator = vorpal => async ({ amount, address, options }) => {
 	validateAmount(amount);
 	validateAddress(address);
 
-	const processFunction = processInputs(amount, address);
+	const normalizedAmount = normalizeAmount(amount);
+	const processFunction = processInputs(normalizedAmount, address);
 
 	return signature === false
 		? processFunction({

--- a/src/commands/create_transaction_transfer.js
+++ b/src/commands/create_transaction_transfer.js
@@ -18,7 +18,6 @@ import {
 	createCommand,
 	normalizeAmount,
 	validateAddress,
-	validateAmount,
 } from '../utils/helpers';
 import commonOptions from '../utils/options';
 import transactions from '../utils/transactions';
@@ -45,9 +44,7 @@ export const actionCreator = vorpal => async ({ amount, address, options }) => {
 		signature,
 	} = options;
 
-	validateAmount(amount);
 	validateAddress(address);
-
 	const normalizedAmount = normalizeAmount(amount);
 	const processFunction = processInputs(normalizedAmount, address);
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -82,6 +82,7 @@ export const validateAmount = amount => {
 };
 
 export const normalizeAmount = amount => {
+	validateAmount(amount);
 	const [preString, postString = ''] = amount.split('.');
 	const [preArray, postArray] = [preString, postString].map(n => Array.from(n));
 	const pad = new Array(DECIMAL_PLACES - postArray.length).fill('0');

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -42,6 +42,7 @@ export const validatePublicKeys = publicKeys =>
 
 const regExpAddress = /^\d{1,21}[L|l]$/;
 const regExpAmount = /^\d+(\.\d{1,8})?$/;
+const DECIMAL_PLACES = 8;
 
 const isStringInteger = n => {
 	const parsed = parseInt(n, 10);
@@ -78,6 +79,16 @@ export const validateAmount = amount => {
 		);
 	}
 	return true;
+};
+
+export const normalizeAmount = amount => {
+	const [preString, postString = ''] = amount.split('.');
+	const [preArray, postArray] = [preString, postString].map(n => Array.from(n));
+	const pad = new Array(DECIMAL_PLACES - postArray.length).fill('0');
+	const combinedArray = [...preArray, ...postArray, ...pad];
+	const combinedString = combinedArray.join('');
+	const trimmed = combinedString.replace(/^0+/, '') || '0';
+	return trimmed;
 };
 
 export const deAlias = type => (type === 'addresses' ? 'accounts' : type);

--- a/test/specs/commands/create_transaction_transfer.js
+++ b/test/specs/commands/create_transaction_transfer.js
@@ -75,246 +75,250 @@ describe('create transaction transfer command', () => {
 												);
 											},
 										);
-										Given('an amount "100.123"', given.anAmount, () => {
-											Given(
-												'an invalid address "1234567890LL"',
-												given.anInvalidAddress,
-												() => {
-													When(
-														'the action is called with the amount, the address and the options',
-														when.theActionIsCalledWithTheAmountTheAddressAndTheOptions,
-														() => {
-															Then(
-																'it should reject with validation error and message "1234567890LL is not a valid address."',
-																then.itShouldRejectWithValidationErrorAndMessage,
-															);
-														},
-													);
-												},
-											);
-											Given(
-												'an address "13356260975429434553L"',
-												given.anAddress,
-												() => {
-													Given(
-														'an error "Unknown data source type." occurs retrieving the inputs from their sources',
-														given.anErrorOccursRetrievingTheInputsFromTheirSources,
-														() => {
-															When(
-																'the action is called with the amount, the address and the options',
-																when.theActionIsCalledWithTheAmountTheAddressAndTheOptions,
-																() => {
-																	Then(
-																		'it should reject with the error message',
-																		then.itShouldRejectWithTheErrorMessage,
-																	);
-																},
-															);
-														},
-													);
-													Given(
-														'the passphrase can be retrieved from its source',
-														given.thePassphraseCanBeRetrievedFromItsSource,
-														() => {
-															When(
-																'the action is called with the amount, the address and the options',
-																when.theActionIsCalledWithTheAmountTheAddressAndTheOptions,
-																() => {
-																	Then(
-																		'it should get the inputs from sources using the Vorpal instance',
-																		then.itShouldGetTheInputsFromSourcesUsingTheVorpalInstance,
-																	);
-																	Then(
-																		'it should get the inputs from sources using the passphrase source with a repeating prompt',
-																		then.itShouldGetTheInputsFromSourcesUsingThePassphraseSourceWithARepeatingPrompt,
-																	);
-																	Then(
-																		'it should not get the inputs from sources using the second passphrase source',
-																		then.itShouldNotGetTheInputsFromSourcesUsingTheSecondPassphraseSource,
-																	);
-																	Then(
-																		'it should create a transfer transaction using the address, the amount and the passphrase',
-																		then.itShouldCreateATransferTransactionUsingTheAddressTheAmountAndThePassphrase,
-																	);
-																	Then(
-																		'it should resolve to the created transaction',
-																		then.itShouldResolveToTheCreatedTransaction,
-																	);
-																},
-															);
-														},
-													);
-													Given(
-														'an options object with passphrase set to "passphraseSource"',
-														given.anOptionsObjectWithPassphraseSetTo,
-														() => {
-															Given(
-																'an error "Unknown data source type." occurs retrieving the inputs from their sources',
-																given.anErrorOccursRetrievingTheInputsFromTheirSources,
-																() => {
-																	When(
-																		'the action is called with the amount, the address and the options',
-																		when.theActionIsCalledWithTheAmountTheAddressAndTheOptions,
-																		() => {
-																			Then(
-																				'it should reject with the error message',
-																				then.itShouldRejectWithTheErrorMessage,
-																			);
-																		},
-																	);
-																},
-															);
-															Given(
-																'the passphrase can be retrieved from its source',
-																given.thePassphraseCanBeRetrievedFromItsSource,
-																() => {
-																	When(
-																		'the action is called with the amount, the address and the options',
-																		when.theActionIsCalledWithTheAmountTheAddressAndTheOptions,
-																		() => {
-																			Then(
-																				'it should get the inputs from sources using the Vorpal instance',
-																				then.itShouldGetTheInputsFromSourcesUsingTheVorpalInstance,
-																			);
-																			Then(
-																				'it should get the inputs from sources using the passphrase source with a repeating prompt',
-																				then.itShouldGetTheInputsFromSourcesUsingThePassphraseSourceWithARepeatingPrompt,
-																			);
-																			Then(
-																				'it should not get the inputs from sources using the second passphrase source',
-																				then.itShouldNotGetTheInputsFromSourcesUsingTheSecondPassphraseSource,
-																			);
-																			Then(
-																				'it should create a transfer transaction using the address, the amount and the passphrase',
-																				then.itShouldCreateATransferTransactionUsingTheAddressTheAmountAndThePassphrase,
-																			);
-																			Then(
-																				'it should resolve to the created transaction',
-																				then.itShouldResolveToTheCreatedTransaction,
-																			);
-																		},
-																	);
-																},
-															);
-														},
-													);
-													Given(
-														'a second passphrase "fame spoil quiz garbage mirror envelope island rapid lend year bike adapt"',
-														given.aSecondPassphrase,
-														() => {
-															Given(
-																'an options object with second passphrase set to "secondPassphraseSource"',
-																given.anOptionsObjectWithSecondPassphraseSetTo,
-																() => {
-																	Given(
-																		'an error "Unknown data source type." occurs retrieving the inputs from their sources',
-																		given.anErrorOccursRetrievingTheInputsFromTheirSources,
-																		() => {
-																			When(
-																				'the action is called with the amount, the address and the options',
-																				when.theActionIsCalledWithTheAmountTheAddressAndTheOptions,
-																				() => {
-																					Then(
-																						'it should reject with the error message',
-																						then.itShouldRejectWithTheErrorMessage,
-																					);
-																				},
-																			);
-																		},
-																	);
-																	Given(
-																		'the passphrase and second passphrase can be retrieved from their sources',
-																		given.thePassphraseAndSecondPassphraseCanBeRetrievedFromTheirSources,
-																		() => {
-																			When(
-																				'the action is called with the amount, the address and the options',
-																				when.theActionIsCalledWithTheAmountTheAddressAndTheOptions,
-																				() => {
-																					Then(
-																						'it should get the inputs from sources using the Vorpal instance',
-																						then.itShouldGetTheInputsFromSourcesUsingTheVorpalInstance,
-																					);
-																					Then(
-																						'it should get the inputs from sources using the passphrase source with a repeating prompt',
-																						then.itShouldGetTheInputsFromSourcesUsingThePassphraseSourceWithARepeatingPrompt,
-																					);
-																					Then(
-																						'it should get the inputs from sources using the second passphrase source with a repeating prompt',
-																						then.itShouldGetTheInputsFromSourcesUsingTheSecondPassphraseSourceWithARepeatingPrompt,
-																					);
-																					Then(
-																						'it should create a transfer transaction using the address, the amount, the passphrase and the second passphrase',
-																						then.itShouldCreateATransferTransactionUsingTheAddressTheAmountThePassphraseAndTheSecondPassphrase,
-																					);
-																					Then(
-																						'it should resolve to the created transaction',
-																						then.itShouldResolveToTheCreatedTransaction,
-																					);
-																				},
-																			);
-																		},
-																	);
-																},
-															);
-															Given(
-																'an options object with passphrase set to "passphraseSource" and second passphrase set to "secondPassphraseSource"',
-																given.anOptionsObjectWithPassphraseSetToAndSecondPassphraseSetTo,
-																() => {
-																	Given(
-																		'an error "Unknown data source type." occurs retrieving the inputs from their sources',
-																		given.anErrorOccursRetrievingTheInputsFromTheirSources,
-																		() => {
-																			When(
-																				'the action is called with the amount, the address and the options',
-																				when.theActionIsCalledWithTheAmountTheAddressAndTheOptions,
-																				() => {
-																					Then(
-																						'it should reject with the error message',
-																						then.itShouldRejectWithTheErrorMessage,
-																					);
-																				},
-																			);
-																		},
-																	);
-																	Given(
-																		'the passphrase and second passphrase can be retrieved from their sources',
-																		given.thePassphraseAndSecondPassphraseCanBeRetrievedFromTheirSources,
-																		() => {
-																			When(
-																				'the action is called with the amount, the address and the options',
-																				when.theActionIsCalledWithTheAmountTheAddressAndTheOptions,
-																				() => {
-																					Then(
-																						'it should get the inputs from sources using the Vorpal instance',
-																						then.itShouldGetTheInputsFromSourcesUsingTheVorpalInstance,
-																					);
-																					Then(
-																						'it should get the inputs from sources using the passphrase source with a repeating prompt',
-																						then.itShouldGetTheInputsFromSourcesUsingThePassphraseSourceWithARepeatingPrompt,
-																					);
-																					Then(
-																						'it should get the inputs from sources using the second passphrase source with a repeating prompt',
-																						then.itShouldGetTheInputsFromSourcesUsingTheSecondPassphraseSourceWithARepeatingPrompt,
-																					);
-																					Then(
-																						'it should create a transfer transaction using the address, the amount, the passphrase and the second passphrase',
-																						then.itShouldCreateATransferTransactionUsingTheAddressTheAmountThePassphraseAndTheSecondPassphrase,
-																					);
-																					Then(
-																						'it should resolve to the created transaction',
-																						then.itShouldResolveToTheCreatedTransaction,
-																					);
-																				},
-																			);
-																		},
-																	);
-																},
-															);
-														},
-													);
-												},
-											);
-										});
+										Given(
+											'an amount "100.123" with normalized amount "10012300000"',
+											given.anAmountWithNormalizedAmount,
+											() => {
+												Given(
+													'an invalid address "1234567890LL"',
+													given.anInvalidAddress,
+													() => {
+														When(
+															'the action is called with the amount, the address and the options',
+															when.theActionIsCalledWithTheAmountTheAddressAndTheOptions,
+															() => {
+																Then(
+																	'it should reject with validation error and message "1234567890LL is not a valid address."',
+																	then.itShouldRejectWithValidationErrorAndMessage,
+																);
+															},
+														);
+													},
+												);
+												Given(
+													'an address "13356260975429434553L"',
+													given.anAddress,
+													() => {
+														Given(
+															'an error "Unknown data source type." occurs retrieving the inputs from their sources',
+															given.anErrorOccursRetrievingTheInputsFromTheirSources,
+															() => {
+																When(
+																	'the action is called with the amount, the address and the options',
+																	when.theActionIsCalledWithTheAmountTheAddressAndTheOptions,
+																	() => {
+																		Then(
+																			'it should reject with the error message',
+																			then.itShouldRejectWithTheErrorMessage,
+																		);
+																	},
+																);
+															},
+														);
+														Given(
+															'the passphrase can be retrieved from its source',
+															given.thePassphraseCanBeRetrievedFromItsSource,
+															() => {
+																When(
+																	'the action is called with the amount, the address and the options',
+																	when.theActionIsCalledWithTheAmountTheAddressAndTheOptions,
+																	() => {
+																		Then(
+																			'it should get the inputs from sources using the Vorpal instance',
+																			then.itShouldGetTheInputsFromSourcesUsingTheVorpalInstance,
+																		);
+																		Then(
+																			'it should get the inputs from sources using the passphrase source with a repeating prompt',
+																			then.itShouldGetTheInputsFromSourcesUsingThePassphraseSourceWithARepeatingPrompt,
+																		);
+																		Then(
+																			'it should not get the inputs from sources using the second passphrase source',
+																			then.itShouldNotGetTheInputsFromSourcesUsingTheSecondPassphraseSource,
+																		);
+																		Then(
+																			'it should create a transfer transaction using the address, the normalized amount and the passphrase',
+																			then.itShouldCreateATransferTransactionUsingTheAddressTheNormalizedAmountAndThePassphrase,
+																		);
+																		Then(
+																			'it should resolve to the created transaction',
+																			then.itShouldResolveToTheCreatedTransaction,
+																		);
+																	},
+																);
+															},
+														);
+														Given(
+															'an options object with passphrase set to "passphraseSource"',
+															given.anOptionsObjectWithPassphraseSetTo,
+															() => {
+																Given(
+																	'an error "Unknown data source type." occurs retrieving the inputs from their sources',
+																	given.anErrorOccursRetrievingTheInputsFromTheirSources,
+																	() => {
+																		When(
+																			'the action is called with the amount, the address and the options',
+																			when.theActionIsCalledWithTheAmountTheAddressAndTheOptions,
+																			() => {
+																				Then(
+																					'it should reject with the error message',
+																					then.itShouldRejectWithTheErrorMessage,
+																				);
+																			},
+																		);
+																	},
+																);
+																Given(
+																	'the passphrase can be retrieved from its source',
+																	given.thePassphraseCanBeRetrievedFromItsSource,
+																	() => {
+																		When(
+																			'the action is called with the amount, the address and the options',
+																			when.theActionIsCalledWithTheAmountTheAddressAndTheOptions,
+																			() => {
+																				Then(
+																					'it should get the inputs from sources using the Vorpal instance',
+																					then.itShouldGetTheInputsFromSourcesUsingTheVorpalInstance,
+																				);
+																				Then(
+																					'it should get the inputs from sources using the passphrase source with a repeating prompt',
+																					then.itShouldGetTheInputsFromSourcesUsingThePassphraseSourceWithARepeatingPrompt,
+																				);
+																				Then(
+																					'it should not get the inputs from sources using the second passphrase source',
+																					then.itShouldNotGetTheInputsFromSourcesUsingTheSecondPassphraseSource,
+																				);
+																				Then(
+																					'it should create a transfer transaction using the address, the normalized amount and the passphrase',
+																					then.itShouldCreateATransferTransactionUsingTheAddressTheNormalizedAmountAndThePassphrase,
+																				);
+																				Then(
+																					'it should resolve to the created transaction',
+																					then.itShouldResolveToTheCreatedTransaction,
+																				);
+																			},
+																		);
+																	},
+																);
+															},
+														);
+														Given(
+															'a second passphrase "fame spoil quiz garbage mirror envelope island rapid lend year bike adapt"',
+															given.aSecondPassphrase,
+															() => {
+																Given(
+																	'an options object with second passphrase set to "secondPassphraseSource"',
+																	given.anOptionsObjectWithSecondPassphraseSetTo,
+																	() => {
+																		Given(
+																			'an error "Unknown data source type." occurs retrieving the inputs from their sources',
+																			given.anErrorOccursRetrievingTheInputsFromTheirSources,
+																			() => {
+																				When(
+																					'the action is called with the amount, the address and the options',
+																					when.theActionIsCalledWithTheAmountTheAddressAndTheOptions,
+																					() => {
+																						Then(
+																							'it should reject with the error message',
+																							then.itShouldRejectWithTheErrorMessage,
+																						);
+																					},
+																				);
+																			},
+																		);
+																		Given(
+																			'the passphrase and second passphrase can be retrieved from their sources',
+																			given.thePassphraseAndSecondPassphraseCanBeRetrievedFromTheirSources,
+																			() => {
+																				When(
+																					'the action is called with the amount, the address and the options',
+																					when.theActionIsCalledWithTheAmountTheAddressAndTheOptions,
+																					() => {
+																						Then(
+																							'it should get the inputs from sources using the Vorpal instance',
+																							then.itShouldGetTheInputsFromSourcesUsingTheVorpalInstance,
+																						);
+																						Then(
+																							'it should get the inputs from sources using the passphrase source with a repeating prompt',
+																							then.itShouldGetTheInputsFromSourcesUsingThePassphraseSourceWithARepeatingPrompt,
+																						);
+																						Then(
+																							'it should get the inputs from sources using the second passphrase source with a repeating prompt',
+																							then.itShouldGetTheInputsFromSourcesUsingTheSecondPassphraseSourceWithARepeatingPrompt,
+																						);
+																						Then(
+																							'it should create a transfer transaction using the address, the normalized amount, the passphrase and the second passphrase',
+																							then.itShouldCreateATransferTransactionUsingTheAddressTheNormalizedAmountThePassphraseAndTheSecondPassphrase,
+																						);
+																						Then(
+																							'it should resolve to the created transaction',
+																							then.itShouldResolveToTheCreatedTransaction,
+																						);
+																					},
+																				);
+																			},
+																		);
+																	},
+																);
+																Given(
+																	'an options object with passphrase set to "passphraseSource" and second passphrase set to "secondPassphraseSource"',
+																	given.anOptionsObjectWithPassphraseSetToAndSecondPassphraseSetTo,
+																	() => {
+																		Given(
+																			'an error "Unknown data source type." occurs retrieving the inputs from their sources',
+																			given.anErrorOccursRetrievingTheInputsFromTheirSources,
+																			() => {
+																				When(
+																					'the action is called with the amount, the address and the options',
+																					when.theActionIsCalledWithTheAmountTheAddressAndTheOptions,
+																					() => {
+																						Then(
+																							'it should reject with the error message',
+																							then.itShouldRejectWithTheErrorMessage,
+																						);
+																					},
+																				);
+																			},
+																		);
+																		Given(
+																			'the passphrase and second passphrase can be retrieved from their sources',
+																			given.thePassphraseAndSecondPassphraseCanBeRetrievedFromTheirSources,
+																			() => {
+																				When(
+																					'the action is called with the amount, the address and the options',
+																					when.theActionIsCalledWithTheAmountTheAddressAndTheOptions,
+																					() => {
+																						Then(
+																							'it should get the inputs from sources using the Vorpal instance',
+																							then.itShouldGetTheInputsFromSourcesUsingTheVorpalInstance,
+																						);
+																						Then(
+																							'it should get the inputs from sources using the passphrase source with a repeating prompt',
+																							then.itShouldGetTheInputsFromSourcesUsingThePassphraseSourceWithARepeatingPrompt,
+																						);
+																						Then(
+																							'it should get the inputs from sources using the second passphrase source with a repeating prompt',
+																							then.itShouldGetTheInputsFromSourcesUsingTheSecondPassphraseSourceWithARepeatingPrompt,
+																						);
+																						Then(
+																							'it should create a transfer transaction using the address, the normalized amount, the passphrase and the second passphrase',
+																							then.itShouldCreateATransferTransactionUsingTheAddressTheNormalizedAmountThePassphraseAndTheSecondPassphrase,
+																						);
+																						Then(
+																							'it should resolve to the created transaction',
+																							then.itShouldResolveToTheCreatedTransaction,
+																						);
+																					},
+																				);
+																			},
+																		);
+																	},
+																);
+															},
+														);
+													},
+												);
+											},
+										);
 									},
 								);
 							},
@@ -327,22 +331,26 @@ describe('create transaction transfer command', () => {
 									'an address "13356260975429434553L"',
 									given.anAddress,
 									() => {
-										Given('an amount "123"', given.anAmount, () => {
-											When(
-												'the action is called with the amount, the address and the options',
-												when.theActionIsCalledWithTheAmountTheAddressAndTheOptions,
-												() => {
-													Then(
-														'it should create a transfer transaction using the address and the amount',
-														then.itShouldCreateATransferTransactionUsingTheAddressAndTheAmount,
-													);
-													Then(
-														'it should resolve to the created transaction',
-														then.itShouldResolveToTheCreatedTransaction,
-													);
-												},
-											);
-										});
+										Given(
+											'an amount "123" with normalized amount "12300000000"',
+											given.anAmountWithNormalizedAmount,
+											() => {
+												When(
+													'the action is called with the amount, the address and the options',
+													when.theActionIsCalledWithTheAmountTheAddressAndTheOptions,
+													() => {
+														Then(
+															'it should create a transfer transaction using the address and the normalized amount',
+															then.itShouldCreateATransferTransactionUsingTheAddressAndTheNormalizedAmount,
+														);
+														Then(
+															'it should resolve to the created transaction',
+															then.itShouldResolveToTheCreatedTransaction,
+														);
+													},
+												);
+											},
+										);
 									},
 								);
 							},

--- a/test/specs/utils/helpers.js
+++ b/test/specs/utils/helpers.js
@@ -268,6 +268,72 @@ describe('utils helpers', () => {
 			);
 		});
 	});
+	describe('#normalizeAmount', () => {
+		Given(
+			'an amount "120" with normalized amount "12000000000"',
+			given.anAmountWithNormalizedAmount,
+			() => {
+				When(
+					'normalizeAmount is called on the amount',
+					when.normalizeAmountIsCalledOnTheAmount,
+					() => {
+						Then(
+							'it should return the normalized amount',
+							then.itShouldReturnTheNormalizedAmount,
+						);
+					},
+				);
+			},
+		);
+		Given(
+			'an amount "123.456" with normalized amount "12345600000"',
+			given.anAmountWithNormalizedAmount,
+			() => {
+				When(
+					'normalizeAmount is called on the amount',
+					when.normalizeAmountIsCalledOnTheAmount,
+					() => {
+						Then(
+							'it should return the normalized amount',
+							then.itShouldReturnTheNormalizedAmount,
+						);
+					},
+				);
+			},
+		);
+		Given(
+			'an amount "0" with normalized amount "0"',
+			given.anAmountWithNormalizedAmount,
+			() => {
+				When(
+					'normalizeAmount is called on the amount',
+					when.normalizeAmountIsCalledOnTheAmount,
+					() => {
+						Then(
+							'it should return the normalized amount',
+							then.itShouldReturnTheNormalizedAmount,
+						);
+					},
+				);
+			},
+		);
+		Given(
+			'an amount "0.00000123" with normalized amount "123"',
+			given.anAmountWithNormalizedAmount,
+			() => {
+				When(
+					'normalizeAmount is called on the amount',
+					when.normalizeAmountIsCalledOnTheAmount,
+					() => {
+						Then(
+							'it should return the normalized amount',
+							then.itShouldReturnTheNormalizedAmount,
+						);
+					},
+				);
+			},
+		);
+	});
 	describe('#deAlias', () => {
 		Given(
 			'a type "addresses" with alias "accounts"',

--- a/test/specs/utils/helpers.js
+++ b/test/specs/utils/helpers.js
@@ -333,6 +333,18 @@ describe('utils helpers', () => {
 				);
 			},
 		);
+		Given('an invalid amount "0.123456789"', given.anInvalidAmount, () => {
+			When(
+				'normalizeAmount is called on the amount',
+				when.normalizeAmountIsCalledOnTheAmount,
+				() => {
+					Then(
+						'it should throw validation error "Amount must be a number with no more than 8 decimal places."',
+						then.itShouldThrowValidationError,
+					);
+				},
+			);
+		});
 	});
 	describe('#deAlias', () => {
 		Given(

--- a/test/steps/domain/1_given.js
+++ b/test/steps/domain/1_given.js
@@ -39,6 +39,12 @@ export function anAmount() {
 	this.test.ctx.amount = getFirstQuotedString(this.test.parent.title);
 }
 
+export function anAmountWithNormalizedAmount() {
+	const [amount, normalizedAmount] = getQuotedStrings(this.test.parent.title);
+	this.test.ctx.amount = amount;
+	this.test.ctx.normalizedAmount = normalizedAmount;
+}
+
 export const anInvalidAmount = anAmount;
 
 export function aKeysgroupWithKeys() {

--- a/test/steps/domain/2_when.js
+++ b/test/steps/domain/2_when.js
@@ -77,8 +77,15 @@ export function validateAmountIsCalledOnTheAmount() {
 
 export function normalizeAmountIsCalledOnTheAmount() {
 	const { amount } = this.test.ctx;
-	const returnValue = normalizeAmount(amount);
-	this.test.ctx.returnValue = returnValue;
+	try {
+		const returnValue = normalizeAmount(amount);
+		this.test.ctx.returnValue = returnValue;
+		return returnValue;
+	} catch (error) {
+		const testFunction = normalizeAmount.bind(null, amount);
+		this.test.ctx.testFunction = testFunction;
+		return testFunction;
+	}
 }
 
 export function deAliasIsCalledOnTheType() {

--- a/test/steps/domain/2_when.js
+++ b/test/steps/domain/2_when.js
@@ -15,6 +15,7 @@
  */
 import {
 	deAlias,
+	normalizeAmount,
 	validateAddress,
 	validateAmount,
 	validateLifetime,
@@ -72,6 +73,12 @@ export function validateAmountIsCalledOnTheAmount() {
 		this.test.ctx.testFunction = testFunction;
 		return testFunction;
 	}
+}
+
+export function normalizeAmountIsCalledOnTheAmount() {
+	const { amount } = this.test.ctx;
+	const returnValue = normalizeAmount(amount);
+	this.test.ctx.returnValue = returnValue;
 }
 
 export function deAliasIsCalledOnTheType() {

--- a/test/steps/domain/3_then.js
+++ b/test/steps/domain/3_then.js
@@ -24,12 +24,17 @@ export function itShouldReturnAnObjectWithTheAddress() {
 	return expect(returnValue).to.eql({ address });
 }
 
+export function itShouldReturnTheNormalizedAmount() {
+	const { returnValue, normalizedAmount } = this.test.ctx;
+	return expect(returnValue).to.equal(normalizedAmount);
+}
+
 export function itShouldReturnTheAlias() {
 	const { returnValue, alias } = this.test.ctx;
-	return expect(returnValue).to.be.equal(alias);
+	return expect(returnValue).to.equal(alias);
 }
 
 export function itShouldReturnTheType() {
 	const { returnValue, type } = this.test.ctx;
-	return expect(returnValue).to.be.equal(type);
+	return expect(returnValue).to.equal(type);
 }

--- a/test/steps/transactions/3_then.js
+++ b/test/steps/transactions/3_then.js
@@ -76,31 +76,36 @@ export function itShouldCreateACastVotesTransactionWithThePassphraseAndThePublic
 	});
 }
 
-export function itShouldCreateATransferTransactionUsingTheAddressAndTheAmount() {
-	const { address, amount } = this.test.ctx;
+export function itShouldCreateATransferTransactionUsingTheAddressAndTheNormalizedAmount() {
+	const { address, normalizedAmount } = this.test.ctx;
 	return expect(transactions.transfer).to.be.calledWithExactly({
 		recipientId: address,
-		amount,
+		amount: normalizedAmount,
 		passphrase: null,
 		secondPassphrase: null,
 	});
 }
 
-export function itShouldCreateATransferTransactionUsingTheAddressTheAmountThePassphraseAndTheSecondPassphrase() {
-	const { passphrase, secondPassphrase, address, amount } = this.test.ctx;
+export function itShouldCreateATransferTransactionUsingTheAddressTheNormalizedAmountThePassphraseAndTheSecondPassphrase() {
+	const {
+		passphrase,
+		secondPassphrase,
+		address,
+		normalizedAmount,
+	} = this.test.ctx;
 	return expect(transactions.transfer).to.be.calledWithExactly({
 		recipientId: address,
-		amount,
+		amount: normalizedAmount,
 		passphrase,
 		secondPassphrase,
 	});
 }
 
-export function itShouldCreateATransferTransactionUsingTheAddressTheAmountAndThePassphrase() {
-	const { passphrase, address, amount } = this.test.ctx;
+export function itShouldCreateATransferTransactionUsingTheAddressTheNormalizedAmountAndThePassphrase() {
+	const { passphrase, address, normalizedAmount } = this.test.ctx;
 	return expect(transactions.transfer).to.be.calledWithExactly({
 		recipientId: address,
-		amount,
+		amount: normalizedAmount,
 		passphrase,
 		secondPassphrase: null,
 	});


### PR DESCRIPTION
### What was the problem?

We were passing lisk-js the amount in whole LSK instead of the smallest denomination.

### How did I fix it?

I added a `normalizeAmount` helper function. Ideally we would have this function in lisk-elements using bignum, but we can do that post-1.0.0.

### How to test it?

`create transaction transfer 100 123L`

### Review checklist

* The PR solves #482 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
