### PR TITLE
Include private key in create account - Closes #486

### DIFF
--- a/src/commands/create_account.js
+++ b/src/commands/create_account.js
@@ -24,11 +24,12 @@ const description = `Returns a randomly-generated mnemonic passphrase with its c
 
 export const actionCreator = () => async () => {
 	const passphrase = createMnemonicPassphrase();
-	const { publicKey } = cryptography.getKeys(passphrase);
+	const { privateKey, publicKey } = cryptography.getKeys(passphrase);
 	const { address } = cryptography.getAddressFromPublicKey(publicKey);
 
 	return {
 		passphrase,
+		privateKey,
 		publicKey,
 		address,
 	};

--- a/test/README.md
+++ b/test/README.md
@@ -35,8 +35,8 @@ describe('create account command', () => {
 						Given('an action "create account"', given.anAction, () => {
 							When('the action is called', when.theActionIsCalled, () => {
 								Then(
-									'it should resolve to an object with the passphrase and the publicKey and the address',
-									then.itShouldResolveToAnObjectWithThePassphraseAndThePublicKeyAndTheAddress,
+									'it should resolve to an object with the passphrase, the private key, the public key and the address',
+									then.itShouldResolveToAnObjectWithThePassphraseThePrivateKeyThePublicKeyAndTheAddress,
 								);
 							});
 						});
@@ -119,15 +119,16 @@ export function theActionIsCalled() {
 ```js
 // test/steps/.../3_then.js
 
-export function itShouldResolveToAnObjectWithThePassphraseAndThePublicKeyAndTheAddress() {
+export function itShouldResolveToAnObjectWithThePassphraseThePrivateKeyThePublicKeyAndTheAddress() {
 	const {
 		returnValue,
 		passphrase,
-		keys: { publicKey },
+		keys: { privateKey, publicKey },
 		address,
 	} = this.test.ctx;
 	const expectedObject = {
 		passphrase,
+		privateKey,
 		publicKey,
 		address,
 	};

--- a/test/specs/commands/create_account.js
+++ b/test/specs/commands/create_account.js
@@ -35,8 +35,8 @@ describe('create account command', () => {
 							Given('an action "create account"', given.anAction, () => {
 								When('the action is called', when.theActionIsCalled, () => {
 									Then(
-										'it should resolve to an object with the passphrase and the publicKey and the address',
-										then.itShouldResolveToAnObjectWithThePassphraseAndThePublicKeyAndTheAddress,
+										'it should resolve to an object with the passphrase, the private key, the public key and the address',
+										then.itShouldResolveToAnObjectWithThePassphraseThePrivateKeyThePublicKeyAndTheAddress,
 									);
 								});
 							});

--- a/test/steps/crypto/3_then.js
+++ b/test/steps/crypto/3_then.js
@@ -115,15 +115,16 @@ export function itShouldResolveToTheResultOfEncryptingTheMessage() {
 	return expect(returnValue).to.eventually.equal(cryptoResult);
 }
 
-export function itShouldResolveToAnObjectWithThePassphraseAndThePublicKeyAndTheAddress() {
+export function itShouldResolveToAnObjectWithThePassphraseThePrivateKeyThePublicKeyAndTheAddress() {
 	const {
 		returnValue,
 		passphrase,
-		keys: { publicKey },
+		keys: { privateKey, publicKey },
 		address,
 	} = this.test.ctx;
 	const expectedObject = {
 		passphrase,
+		privateKey,
 		publicKey,
 		address,
 	};


### PR DESCRIPTION
### What was the problem?

`create account` didn't give you the private key.

### How did I fix it?

I added the private key to the returned object.

### How to test it?

`create account`

### Review checklist

* The PR solves #486 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated

@diego-G
