### PR TITLE
Bump cli-table2 to use latest GitHub commit - Closes #487

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
 		"babel-polyfill": "=6.26.0",
 		"bip39": "=2.4.0",
 		"chalk": "=2.3.0",
-		"cli-table2": "=0.2.0",
+		"cli-table2":
+			"jamestalmage/cli-table2#187c6ae80b9d963c598d0cb3379153387bfb15c4",
 		"lisk-js": "beta",
 		"lockfile": "=1.0.3",
 		"semver": "=5.5.0",


### PR DESCRIPTION
### What was the problem?

cli-table2 hasn't seen a new release despite some updates, including removing a vulnerable version of lodash.

### How did I fix it?

Updated to a GitHub commit hash.

### How to test it?

Try out commands with table output.

### Review checklist

* The PR solves #487 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
