### PR TITLE
Update config from api.node to api.nodes - Closes #481

### DIFF
--- a/default_config.json
+++ b/default_config.json
@@ -2,7 +2,7 @@
 	"name": "lisky",
 	"json": false,
 	"api": {
-		"node": "",
+		"nodes": [],
 		"network": ""
 	},
 	"pretty": false

--- a/default_config.json
+++ b/default_config.json
@@ -3,7 +3,7 @@
 	"json": false,
 	"api": {
 		"nodes": [],
-		"network": ""
+		"network": "main"
 	},
 	"pretty": false
 }

--- a/src/commands/set.js
+++ b/src/commands/set.js
@@ -136,9 +136,9 @@ export const actionCreator = () => async ({ variable, values }) => {
 	if (!CONFIG_VARIABLES.includes(variable)) {
 		throw new ValidationError('Unsupported variable name.');
 	}
-	const safeInputs = values || [];
-	const safeValue = safeInputs[0] || '';
-	return handlers[variable](variable, safeValue, safeInputs);
+	const safeValues = values || [];
+	const safeValue = safeValues[0] || '';
+	return handlers[variable](variable, safeValue, safeValues);
 };
 
 const set = createCommand({

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -26,10 +26,10 @@ const seedNodes = {
 };
 
 const getAPIClient = () => {
-	const { node, network } = config.api;
+	const { nodes, network } = config.api;
 	const nethash = NETHASHES[network] || network;
-	const nodes = node ? [node] : seedNodes[network];
-	return new APIClient(nodes, nethash);
+	const clientNodes = nodes && nodes.length > 0 ? nodes : seedNodes[network];
+	return new APIClient(clientNodes, nethash);
 };
 
 export default getAPIClient;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -41,7 +41,7 @@ export const QUERY_INPUT_MAP = {
 };
 
 export const CONFIG_VARIABLES = [
-	'api.node',
+	'api.nodes',
 	'api.network',
 	'json',
 	'name',

--- a/test/specs/commands/set.js
+++ b/test/specs/commands/set.js
@@ -32,10 +32,10 @@ describe('set command', () => {
 						given.aConfigWithUnknownProperties,
 						() => {
 							Given('a variable "api.nodes"', given.aVariable, () => {
-								Given('inputs "true"', given.inputs, () => {
+								Given('values "true"', given.values, () => {
 									When(
-										'the action is called with the variable and the inputs',
-										when.theActionIsCalledWithTheVariableAndTheInputs,
+										'the action is called with the variable and the values',
+										when.theActionIsCalledWithTheVariableAndTheValues,
 										() => {
 											Then(
 												"it should reject with validation error and message \"Config file could not be written: property 'api.nodes' was not found. It looks like your configuration file is corrupted. Please check the file or run 'lisky clean' to remove it (a fresh default configuration file will be created when you run Lisky again).\"",
@@ -49,10 +49,10 @@ describe('set command', () => {
 					);
 					Given('a config', given.aConfig, () => {
 						Given('an unknown variable "xxx"', given.anUnknownVariable, () => {
-							Given('inputs "true"', given.inputs, () => {
+							Given('values "true"', given.values, () => {
 								When(
-									'the action is called with the variable and the inputs',
-									when.theActionIsCalledWithTheVariableAndTheInputs,
+									'the action is called with the variable and the values',
+									when.theActionIsCalledWithTheVariableAndTheValues,
 									() => {
 										Then(
 											'it should reject with validation error and message "Unsupported variable name."',
@@ -65,8 +65,8 @@ describe('set command', () => {
 						Given('a variable "json"', given.aVariable, () => {
 							Given('an unknown value "xxx"', given.anUnknownValue, () => {
 								When(
-									'the action is called with the variable and the inputs',
-									when.theActionIsCalledWithTheVariableAndTheInputs,
+									'the action is called with the variable and the values',
+									when.theActionIsCalledWithTheVariableAndTheValues,
 									() => {
 										Then(
 											'it should reject with validation error and message "Value must be a boolean."',
@@ -75,7 +75,7 @@ describe('set command', () => {
 									},
 								);
 							});
-							Given('inputs "true"', given.inputs, () => {
+							Given('values "true"', given.values, () => {
 								Given(
 									'the config file cannot be written',
 									given.theConfigFileCannotBeWritten,
@@ -85,8 +85,8 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
 															'it should reject with file system error and message "Config file could not be written: your changes will not be persisted."',
@@ -101,8 +101,8 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
 															'it should update the config variable "json" to boolean true',
@@ -131,8 +131,8 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
 															'it should update the config variable "json" to boolean true',
@@ -155,8 +155,8 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
 															'it should update the config variable "json" to boolean true',
@@ -177,7 +177,7 @@ describe('set command', () => {
 									},
 								);
 							});
-							Given('inputs "false"', given.inputs, () => {
+							Given('values "false"', given.values, () => {
 								Given(
 									'the config file cannot be written',
 									given.theConfigFileCannotBeWritten,
@@ -187,8 +187,8 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
 															'it should reject with file system error and message "Config file could not be written: your changes will not be persisted."',
@@ -203,8 +203,8 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
 															'it should update the config variable "json" to boolean false',
@@ -233,8 +233,8 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
 															'it should update the config variable "json" to boolean false',
@@ -257,8 +257,8 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
 															'it should update the config variable "json" to boolean false',
@@ -281,7 +281,7 @@ describe('set command', () => {
 							});
 						});
 						Given('a variable "name"', given.aVariable, () => {
-							Given('inputs "my_custom_lisky"', given.inputs, () => {
+							Given('values "my_custom_lisky"', given.values, () => {
 								Given(
 									'the config file cannot be written',
 									given.theConfigFileCannotBeWritten,
@@ -291,8 +291,8 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
 															'it should reject with file system error and message "Config file could not be written: your changes will not be persisted."',
@@ -307,12 +307,12 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should update the config variable "name" to the first inputs',
-															then.itShouldUpdateTheConfigVariableToTheFirstInputs,
+															'it should update the config variable "name" to the first value',
+															then.itShouldUpdateTheConfigVariableToTheFirstValue,
 														);
 														Then(
 															'it should resolve to an object with warning "Config file could not be written: your changes will not be persisted."',
@@ -337,12 +337,12 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should update the config variable "name" to the first inputs',
-															then.itShouldUpdateTheConfigVariableToTheFirstInputs,
+															'it should update the config variable "name" to the first value',
+															then.itShouldUpdateTheConfigVariableToTheFirstValue,
 														);
 														Then(
 															'it should write the updated config to the config file',
@@ -361,12 +361,12 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should update the config variable "name" to the first inputs',
-															then.itShouldUpdateTheConfigVariableToTheFirstInputs,
+															'it should update the config variable "name" to the first value',
+															then.itShouldUpdateTheConfigVariableToTheFirstValue,
 														);
 														Then(
 															'it should write the updated config to the config file',
@@ -387,8 +387,8 @@ describe('set command', () => {
 						Given('a variable "pretty"', given.aVariable, () => {
 							Given('an unknown value "xxx"', given.anUnknownValue, () => {
 								When(
-									'the action is called with the variable and the inputs',
-									when.theActionIsCalledWithTheVariableAndTheInputs,
+									'the action is called with the variable and the values',
+									when.theActionIsCalledWithTheVariableAndTheValues,
 									() => {
 										Then(
 											'it should reject with validation error and message "Value must be a boolean."',
@@ -397,7 +397,7 @@ describe('set command', () => {
 									},
 								);
 							});
-							Given('inputs "true"', given.inputs, () => {
+							Given('values "true"', given.values, () => {
 								Given(
 									'the config file cannot be written',
 									given.theConfigFileCannotBeWritten,
@@ -407,8 +407,8 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
 															'it should reject with file system error and message "Config file could not be written: your changes will not be persisted."',
@@ -423,8 +423,8 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
 															'it should update the config variable "pretty" to boolean true',
@@ -453,8 +453,8 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
 															'it should update the config variable "pretty" to boolean true',
@@ -477,8 +477,8 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
 															'it should update the config variable "pretty" to boolean true',
@@ -499,7 +499,7 @@ describe('set command', () => {
 									},
 								);
 							});
-							Given('inputs "false"', given.inputs, () => {
+							Given('values "false"', given.values, () => {
 								Given(
 									'the config file cannot be written',
 									given.theConfigFileCannotBeWritten,
@@ -509,8 +509,8 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
 															'it should reject with file system error and message "Config file could not be written: your changes will not be persisted."',
@@ -525,8 +525,8 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
 															'it should update the config variable "pretty" to boolean false',
@@ -555,8 +555,8 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
 															'it should update the config variable "pretty" to boolean false',
@@ -579,8 +579,8 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
 															'it should update the config variable "pretty" to boolean false',
@@ -604,8 +604,8 @@ describe('set command', () => {
 						});
 						Given('a variable "api.nodes"', given.aVariable, () => {
 							Given(
-								'inputs "localhost" and "http://127.0.0.1"',
-								given.inputs,
+								'values "localhost" and "http://127.0.0.1"',
+								given.values,
 								() => {
 									Given(
 										'the config file can be written',
@@ -616,12 +616,12 @@ describe('set command', () => {
 												given.vorpalIsInNonInteractiveMode,
 												() => {
 													When(
-														'the action is called with the variable and the inputs',
-														when.theActionIsCalledWithTheVariableAndTheInputs,
+														'the action is called with the variable and the values',
+														when.theActionIsCalledWithTheVariableAndTheValues,
 														() => {
 															Then(
-																'it should update the config nested variable "api.nodes" to the inputs',
-																then.itShouldUpdateTheConfigNestedVariableToTheInputs,
+																'it should update the config nested variable "api.nodes" to the values',
+																then.itShouldUpdateTheConfigNestedVariableToTheValues,
 															);
 															Then(
 																'it should write the updated config to the config file',
@@ -640,12 +640,12 @@ describe('set command', () => {
 												given.vorpalIsInInteractiveMode,
 												() => {
 													When(
-														'the action is called with the variable and the inputs',
-														when.theActionIsCalledWithTheVariableAndTheInputs,
+														'the action is called with the variable and the values',
+														when.theActionIsCalledWithTheVariableAndTheValues,
 														() => {
 															Then(
-																'it should update the config nested variable "api.nodes" to the inputs',
-																then.itShouldUpdateTheConfigNestedVariableToTheInputs,
+																'it should update the config nested variable "api.nodes" to the values',
+																then.itShouldUpdateTheConfigNestedVariableToTheValues,
 															);
 															Then(
 																'it should write the updated config to the config file',
@@ -663,7 +663,7 @@ describe('set command', () => {
 									);
 								},
 							);
-							Given('inputs "http://localhost:4000"', given.inputs, () => {
+							Given('values "http://localhost:4000"', given.values, () => {
 								Given(
 									'the config file can be written',
 									given.theConfigFileCanBeWritten,
@@ -673,12 +673,12 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should update the config nested variable "api.nodes" to the inputs',
-															then.itShouldUpdateTheConfigNestedVariableToTheInputs,
+															'it should update the config nested variable "api.nodes" to the values',
+															then.itShouldUpdateTheConfigNestedVariableToTheValues,
 														);
 														Then(
 															'it should write the updated config to the config file',
@@ -697,12 +697,12 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should update the config nested variable "api.nodes" to the inputs',
-															then.itShouldUpdateTheConfigNestedVariableToTheInputs,
+															'it should update the config nested variable "api.nodes" to the values',
+															then.itShouldUpdateTheConfigNestedVariableToTheValues,
 														);
 														Then(
 															'it should write the updated config to the config file',
@@ -719,7 +719,7 @@ describe('set command', () => {
 									},
 								);
 							});
-							Given('inputs ""', given.inputs, () => {
+							Given('values ""', given.values, () => {
 								Given(
 									'the config file can be written',
 									given.theConfigFileCanBeWritten,
@@ -729,19 +729,19 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should update the config nested variable "api.nodes" to the inputs',
-															then.itShouldUpdateTheConfigNestedVariableToTheInputs,
+															'it should update the config nested variable "api.nodes" to the values',
+															then.itShouldUpdateTheConfigNestedVariableToTheValues,
 														);
 														Then(
 															'it should write the updated config to the config file',
 															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
 														);
 														Then(
-															'it should resolve to an object with message "Successfully set api.nodes to ."',
+															'it should resolve to an object with message "Successfully reset api.nodes."',
 															then.itShouldResolveToAnObjectWithMessage,
 														);
 													},
@@ -753,19 +753,19 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should update the config nested variable "api.nodes" to the inputs',
-															then.itShouldUpdateTheConfigNestedVariableToTheInputs,
+															'it should update the config nested variable "api.nodes" to the values',
+															then.itShouldUpdateTheConfigNestedVariableToTheValues,
 														);
 														Then(
 															'it should write the updated config to the config file',
 															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
 														);
 														Then(
-															'it should resolve to an object with message "Successfully set api.nodes to ."',
+															'it should resolve to an object with message "Successfully reset api.nodes."',
 															then.itShouldResolveToAnObjectWithMessage,
 														);
 													},
@@ -775,12 +775,66 @@ describe('set command', () => {
 									},
 								);
 							});
+							Given(
+								'the config file can be written',
+								given.theConfigFileCanBeWritten,
+								() => {
+									Given(
+										'Vorpal is in non-interactive mode',
+										given.vorpalIsInNonInteractiveMode,
+										() => {
+											When(
+												'the action is called with the variable and the values',
+												when.theActionIsCalledWithTheVariableAndTheValues,
+												() => {
+													Then(
+														'it should update the config nested variable "api.nodes" to empty array',
+														then.itShouldUpdateTheConfigNestedVariableToEmptyArray,
+													);
+													Then(
+														'it should write the updated config to the config file',
+														then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+													);
+													Then(
+														'it should resolve to an object with message "Successfully reset api.nodes."',
+														then.itShouldResolveToAnObjectWithMessage,
+													);
+												},
+											);
+										},
+									);
+									Given(
+										'Vorpal is in interactive mode',
+										given.vorpalIsInInteractiveMode,
+										() => {
+											When(
+												'the action is called with the variable and the values',
+												when.theActionIsCalledWithTheVariableAndTheValues,
+												() => {
+													Then(
+														'it should update the config nested variable "api.nodes" to empty array',
+														then.itShouldUpdateTheConfigNestedVariableToEmptyArray,
+													);
+													Then(
+														'it should write the updated config to the config file',
+														then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+													);
+													Then(
+														'it should resolve to an object with message "Successfully reset api.nodes."',
+														then.itShouldResolveToAnObjectWithMessage,
+													);
+												},
+											);
+										},
+									);
+								},
+							);
 						});
 						Given('a variable "api.network"', given.aVariable, () => {
 							Given('an unknown value "xxx"', given.anUnknownValue, () => {
 								When(
-									'the action is called with the variable and the inputs',
-									when.theActionIsCalledWithTheVariableAndTheInputs,
+									'the action is called with the variable and the values',
+									when.theActionIsCalledWithTheVariableAndTheValues,
 									() => {
 										Then(
 											'it should reject with validation error and message "Value must be a hex string with 64 characters, or one of main, test or beta."',
@@ -790,12 +844,12 @@ describe('set command', () => {
 								);
 							});
 							Given(
-								'inputs "ed14889723f24ecc54871d058d98ce91ff2f97"',
-								given.inputs,
+								'values "ed14889723f24ecc54871d058d98ce91ff2f97"',
+								given.values,
 								() => {
 									When(
-										'the action is called with the variable and the inputs',
-										when.theActionIsCalledWithTheVariableAndTheInputs,
+										'the action is called with the variable and the values',
+										when.theActionIsCalledWithTheVariableAndTheValues,
 										() => {
 											Then(
 												'it should reject with validation error and message "Value must be a hex string with 64 characters, or one of main, test or beta."',
@@ -806,12 +860,12 @@ describe('set command', () => {
 								},
 							);
 							Given(
-								'inputs "ed14889723f24ecc54871d058xxxxxxxxxxxxxxxxxxxxxxxxxba2b7b70ad2500"',
-								given.inputs,
+								'values "ed14889723f24ecc54871d058xxxxxxxxxxxxxxxxxxxxxxxxxba2b7b70ad2500"',
+								given.values,
 								() => {
 									When(
-										'the action is called with the variable and the inputs',
-										when.theActionIsCalledWithTheVariableAndTheInputs,
+										'the action is called with the variable and the values',
+										when.theActionIsCalledWithTheVariableAndTheValues,
 										() => {
 											Then(
 												'it should reject with validation error and message "Value must be a hex string with 64 characters, or one of main, test or beta."',
@@ -821,7 +875,7 @@ describe('set command', () => {
 									);
 								},
 							);
-							Given('inputs "main"', given.inputs, () => {
+							Given('values "main"', given.values, () => {
 								Given(
 									'the config file can be written',
 									given.theConfigFileCanBeWritten,
@@ -831,12 +885,12 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should update the config nested variable "api.network" to the first inputs',
-															then.itShouldUpdateTheConfigNestedVariableToTheFirstInputs,
+															'it should update the config nested variable "api.network" to the first value',
+															then.itShouldUpdateTheConfigNestedVariableToTheFirstValue,
 														);
 														Then(
 															'it should write the updated config to the config file',
@@ -855,12 +909,12 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should update the config nested variable "api.network" to the first inputs',
-															then.itShouldUpdateTheConfigNestedVariableToTheFirstInputs,
+															'it should update the config nested variable "api.network" to the first value',
+															then.itShouldUpdateTheConfigNestedVariableToTheFirstValue,
 														);
 														Then(
 															'it should write the updated config to the config file',
@@ -877,7 +931,7 @@ describe('set command', () => {
 									},
 								);
 							});
-							Given('inputs "test"', given.inputs, () => {
+							Given('values "test"', given.values, () => {
 								Given(
 									'the config file can be written',
 									given.theConfigFileCanBeWritten,
@@ -887,12 +941,12 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should update the config nested variable "api.network" to the first inputs',
-															then.itShouldUpdateTheConfigNestedVariableToTheFirstInputs,
+															'it should update the config nested variable "api.network" to the first value',
+															then.itShouldUpdateTheConfigNestedVariableToTheFirstValue,
 														);
 														Then(
 															'it should write the updated config to the config file',
@@ -911,12 +965,12 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should update the config nested variable "api.network" to the first inputs',
-															then.itShouldUpdateTheConfigNestedVariableToTheFirstInputs,
+															'it should update the config nested variable "api.network" to the first value',
+															then.itShouldUpdateTheConfigNestedVariableToTheFirstValue,
 														);
 														Then(
 															'it should write the updated config to the config file',
@@ -933,7 +987,7 @@ describe('set command', () => {
 									},
 								);
 							});
-							Given('inputs "beta"', given.inputs, () => {
+							Given('values "beta"', given.values, () => {
 								Given(
 									'the config file can be written',
 									given.theConfigFileCanBeWritten,
@@ -943,12 +997,12 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should update the config nested variable "api.network" to the first inputs',
-															then.itShouldUpdateTheConfigNestedVariableToTheFirstInputs,
+															'it should update the config nested variable "api.network" to the first value',
+															then.itShouldUpdateTheConfigNestedVariableToTheFirstValue,
 														);
 														Then(
 															'it should write the updated config to the config file',
@@ -967,12 +1021,12 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the inputs',
-													when.theActionIsCalledWithTheVariableAndTheInputs,
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should update the config nested variable "api.network" to the first inputs',
-															then.itShouldUpdateTheConfigNestedVariableToTheFirstInputs,
+															'it should update the config nested variable "api.network" to the first value',
+															then.itShouldUpdateTheConfigNestedVariableToTheFirstValue,
 														);
 														Then(
 															'it should write the updated config to the config file',
@@ -990,8 +1044,8 @@ describe('set command', () => {
 								);
 							});
 							Given(
-								'inputs "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"',
-								given.inputs,
+								'values "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"',
+								given.values,
 								() => {
 									Given(
 										'the config file cannot be written',
@@ -1002,8 +1056,8 @@ describe('set command', () => {
 												given.vorpalIsInNonInteractiveMode,
 												() => {
 													When(
-														'the action is called with the variable and the inputs',
-														when.theActionIsCalledWithTheVariableAndTheInputs,
+														'the action is called with the variable and the values',
+														when.theActionIsCalledWithTheVariableAndTheValues,
 														() => {
 															Then(
 																'it should reject with file system error and message "Config file could not be written: your changes will not be persisted."',
@@ -1018,12 +1072,12 @@ describe('set command', () => {
 												given.vorpalIsInInteractiveMode,
 												() => {
 													When(
-														'the action is called with the variable and the inputs',
-														when.theActionIsCalledWithTheVariableAndTheInputs,
+														'the action is called with the variable and the values',
+														when.theActionIsCalledWithTheVariableAndTheValues,
 														() => {
 															Then(
-																'it should update the config nested variable "api.network" to the first inputs',
-																then.itShouldUpdateTheConfigNestedVariableToTheFirstInputs,
+																'it should update the config nested variable "api.network" to the first value',
+																then.itShouldUpdateTheConfigNestedVariableToTheFirstValue,
 															);
 															Then(
 																'it should resolve to an object with warning "Config file could not be written: your changes will not be persisted."',
@@ -1048,12 +1102,12 @@ describe('set command', () => {
 												given.vorpalIsInNonInteractiveMode,
 												() => {
 													When(
-														'the action is called with the variable and the inputs',
-														when.theActionIsCalledWithTheVariableAndTheInputs,
+														'the action is called with the variable and the values',
+														when.theActionIsCalledWithTheVariableAndTheValues,
 														() => {
 															Then(
-																'it should update the config nested variable "api.network" to the first inputs',
-																then.itShouldUpdateTheConfigNestedVariableToTheFirstInputs,
+																'it should update the config nested variable "api.network" to the first value',
+																then.itShouldUpdateTheConfigNestedVariableToTheFirstValue,
 															);
 															Then(
 																'it should write the updated config to the config file',
@@ -1072,12 +1126,12 @@ describe('set command', () => {
 												given.vorpalIsInInteractiveMode,
 												() => {
 													When(
-														'the action is called with the variable and the inputs',
-														when.theActionIsCalledWithTheVariableAndTheInputs,
+														'the action is called with the variable and the values',
+														when.theActionIsCalledWithTheVariableAndTheValues,
 														() => {
 															Then(
-																'it should update the config nested variable "api.network" to the first inputs',
-																then.itShouldUpdateTheConfigNestedVariableToTheFirstInputs,
+																'it should update the config nested variable "api.network" to the first value',
+																then.itShouldUpdateTheConfigNestedVariableToTheFirstValue,
 															);
 															Then(
 																'it should write the updated config to the config file',

--- a/test/specs/commands/set.js
+++ b/test/specs/commands/set.js
@@ -31,14 +31,14 @@ describe('set command', () => {
 						'a config with unknown properties',
 						given.aConfigWithUnknownProperties,
 						() => {
-							Given('a variable "api.node"', given.aVariable, () => {
-								Given('a value "true"', given.aValue, () => {
+							Given('a variable "api.nodes"', given.aVariable, () => {
+								Given('inputs "true"', given.inputs, () => {
 									When(
-										'the action is called with the variable and the value',
-										when.theActionIsCalledWithTheVariableAndTheValue,
+										'the action is called with the variable and the inputs',
+										when.theActionIsCalledWithTheVariableAndTheInputs,
 										() => {
 											Then(
-												"it should reject with validation error and message \"Config file could not be written: property 'api.node' was not found. It looks like your configuration file is corrupted. Please check the file or run 'lisky clean' to remove it (a fresh default configuration file will be created when you run Lisky again).\"",
+												"it should reject with validation error and message \"Config file could not be written: property 'api.nodes' was not found. It looks like your configuration file is corrupted. Please check the file or run 'lisky clean' to remove it (a fresh default configuration file will be created when you run Lisky again).\"",
 												then.itShouldRejectWithValidationErrorAndMessage,
 											);
 										},
@@ -49,10 +49,10 @@ describe('set command', () => {
 					);
 					Given('a config', given.aConfig, () => {
 						Given('an unknown variable "xxx"', given.anUnknownVariable, () => {
-							Given('a value "true"', given.aValue, () => {
+							Given('inputs "true"', given.inputs, () => {
 								When(
-									'the action is called with the variable and the value',
-									when.theActionIsCalledWithTheVariableAndTheValue,
+									'the action is called with the variable and the inputs',
+									when.theActionIsCalledWithTheVariableAndTheInputs,
 									() => {
 										Then(
 											'it should reject with validation error and message "Unsupported variable name."',
@@ -65,8 +65,8 @@ describe('set command', () => {
 						Given('a variable "json"', given.aVariable, () => {
 							Given('an unknown value "xxx"', given.anUnknownValue, () => {
 								When(
-									'the action is called with the variable and the value',
-									when.theActionIsCalledWithTheVariableAndTheValue,
+									'the action is called with the variable and the inputs',
+									when.theActionIsCalledWithTheVariableAndTheInputs,
 									() => {
 										Then(
 											'it should reject with validation error and message "Value must be a boolean."',
@@ -75,7 +75,7 @@ describe('set command', () => {
 									},
 								);
 							});
-							Given('a value "true"', given.aValue, () => {
+							Given('inputs "true"', given.inputs, () => {
 								Given(
 									'the config file cannot be written',
 									given.theConfigFileCannotBeWritten,
@@ -85,8 +85,8 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
 															'it should reject with file system error and message "Config file could not be written: your changes will not be persisted."',
@@ -101,8 +101,8 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
 															'it should update the config variable "json" to boolean true',
@@ -131,8 +131,8 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
 															'it should update the config variable "json" to boolean true',
@@ -155,8 +155,8 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
 															'it should update the config variable "json" to boolean true',
@@ -177,7 +177,7 @@ describe('set command', () => {
 									},
 								);
 							});
-							Given('a value "false"', given.aValue, () => {
+							Given('inputs "false"', given.inputs, () => {
 								Given(
 									'the config file cannot be written',
 									given.theConfigFileCannotBeWritten,
@@ -187,8 +187,8 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
 															'it should reject with file system error and message "Config file could not be written: your changes will not be persisted."',
@@ -203,8 +203,8 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
 															'it should update the config variable "json" to boolean false',
@@ -233,8 +233,8 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
 															'it should update the config variable "json" to boolean false',
@@ -257,8 +257,8 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
 															'it should update the config variable "json" to boolean false',
@@ -281,7 +281,7 @@ describe('set command', () => {
 							});
 						});
 						Given('a variable "name"', given.aVariable, () => {
-							Given('a value "my_custom_lisky"', given.aValue, () => {
+							Given('inputs "my_custom_lisky"', given.inputs, () => {
 								Given(
 									'the config file cannot be written',
 									given.theConfigFileCannotBeWritten,
@@ -291,8 +291,8 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
 															'it should reject with file system error and message "Config file could not be written: your changes will not be persisted."',
@@ -307,12 +307,12 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
-															'it should update the config variable "name" to the value',
-															then.itShouldUpdateTheConfigVariableToTheValue,
+															'it should update the config variable "name" to the first inputs',
+															then.itShouldUpdateTheConfigVariableToTheFirstInputs,
 														);
 														Then(
 															'it should resolve to an object with warning "Config file could not be written: your changes will not be persisted."',
@@ -337,12 +337,12 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
-															'it should update the config variable "name" to the value',
-															then.itShouldUpdateTheConfigVariableToTheValue,
+															'it should update the config variable "name" to the first inputs',
+															then.itShouldUpdateTheConfigVariableToTheFirstInputs,
 														);
 														Then(
 															'it should write the updated config to the config file',
@@ -361,12 +361,12 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
-															'it should update the config variable "name" to the value',
-															then.itShouldUpdateTheConfigVariableToTheValue,
+															'it should update the config variable "name" to the first inputs',
+															then.itShouldUpdateTheConfigVariableToTheFirstInputs,
 														);
 														Then(
 															'it should write the updated config to the config file',
@@ -387,8 +387,8 @@ describe('set command', () => {
 						Given('a variable "pretty"', given.aVariable, () => {
 							Given('an unknown value "xxx"', given.anUnknownValue, () => {
 								When(
-									'the action is called with the variable and the value',
-									when.theActionIsCalledWithTheVariableAndTheValue,
+									'the action is called with the variable and the inputs',
+									when.theActionIsCalledWithTheVariableAndTheInputs,
 									() => {
 										Then(
 											'it should reject with validation error and message "Value must be a boolean."',
@@ -397,7 +397,7 @@ describe('set command', () => {
 									},
 								);
 							});
-							Given('a value "true"', given.aValue, () => {
+							Given('inputs "true"', given.inputs, () => {
 								Given(
 									'the config file cannot be written',
 									given.theConfigFileCannotBeWritten,
@@ -407,8 +407,8 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
 															'it should reject with file system error and message "Config file could not be written: your changes will not be persisted."',
@@ -423,8 +423,8 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
 															'it should update the config variable "pretty" to boolean true',
@@ -453,8 +453,8 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
 															'it should update the config variable "pretty" to boolean true',
@@ -477,8 +477,8 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
 															'it should update the config variable "pretty" to boolean true',
@@ -499,7 +499,7 @@ describe('set command', () => {
 									},
 								);
 							});
-							Given('a value "false"', given.aValue, () => {
+							Given('inputs "false"', given.inputs, () => {
 								Given(
 									'the config file cannot be written',
 									given.theConfigFileCannotBeWritten,
@@ -509,8 +509,8 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
 															'it should reject with file system error and message "Config file could not be written: your changes will not be persisted."',
@@ -525,8 +525,8 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
 															'it should update the config variable "pretty" to boolean false',
@@ -555,8 +555,8 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
 															'it should update the config variable "pretty" to boolean false',
@@ -579,8 +579,8 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
 															'it should update the config variable "pretty" to boolean false',
@@ -602,11 +602,185 @@ describe('set command', () => {
 								);
 							});
 						});
+						Given('a variable "api.nodes"', given.aVariable, () => {
+							Given(
+								'inputs "localhost" and "http://127.0.0.1"',
+								given.inputs,
+								() => {
+									Given(
+										'the config file can be written',
+										given.theConfigFileCanBeWritten,
+										() => {
+											Given(
+												'Vorpal is in non-interactive mode',
+												given.vorpalIsInNonInteractiveMode,
+												() => {
+													When(
+														'the action is called with the variable and the inputs',
+														when.theActionIsCalledWithTheVariableAndTheInputs,
+														() => {
+															Then(
+																'it should update the config nested variable "api.nodes" to the inputs',
+																then.itShouldUpdateTheConfigNestedVariableToTheInputs,
+															);
+															Then(
+																'it should write the updated config to the config file',
+																then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															);
+															Then(
+																'it should resolve to an object with message "Successfully set api.nodes to localhost,http://127.0.0.1."',
+																then.itShouldResolveToAnObjectWithMessage,
+															);
+														},
+													);
+												},
+											);
+											Given(
+												'Vorpal is in interactive mode',
+												given.vorpalIsInInteractiveMode,
+												() => {
+													When(
+														'the action is called with the variable and the inputs',
+														when.theActionIsCalledWithTheVariableAndTheInputs,
+														() => {
+															Then(
+																'it should update the config nested variable "api.nodes" to the inputs',
+																then.itShouldUpdateTheConfigNestedVariableToTheInputs,
+															);
+															Then(
+																'it should write the updated config to the config file',
+																then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															);
+															Then(
+																'it should resolve to an object with message "Successfully set api.nodes to localhost,http://127.0.0.1."',
+																then.itShouldResolveToAnObjectWithMessage,
+															);
+														},
+													);
+												},
+											);
+										},
+									);
+								},
+							);
+							Given('inputs "http://localhost:4000"', given.inputs, () => {
+								Given(
+									'the config file can be written',
+									given.theConfigFileCanBeWritten,
+									() => {
+										Given(
+											'Vorpal is in non-interactive mode',
+											given.vorpalIsInNonInteractiveMode,
+											() => {
+												When(
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
+													() => {
+														Then(
+															'it should update the config nested variable "api.nodes" to the inputs',
+															then.itShouldUpdateTheConfigNestedVariableToTheInputs,
+														);
+														Then(
+															'it should write the updated config to the config file',
+															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+														);
+														Then(
+															'it should resolve to an object with message "Successfully set api.nodes to http://localhost:4000."',
+															then.itShouldResolveToAnObjectWithMessage,
+														);
+													},
+												);
+											},
+										);
+										Given(
+											'Vorpal is in interactive mode',
+											given.vorpalIsInInteractiveMode,
+											() => {
+												When(
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
+													() => {
+														Then(
+															'it should update the config nested variable "api.nodes" to the inputs',
+															then.itShouldUpdateTheConfigNestedVariableToTheInputs,
+														);
+														Then(
+															'it should write the updated config to the config file',
+															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+														);
+														Then(
+															'it should resolve to an object with message "Successfully set api.nodes to http://localhost:4000."',
+															then.itShouldResolveToAnObjectWithMessage,
+														);
+													},
+												);
+											},
+										);
+									},
+								);
+							});
+							Given('inputs ""', given.inputs, () => {
+								Given(
+									'the config file can be written',
+									given.theConfigFileCanBeWritten,
+									() => {
+										Given(
+											'Vorpal is in non-interactive mode',
+											given.vorpalIsInNonInteractiveMode,
+											() => {
+												When(
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
+													() => {
+														Then(
+															'it should update the config nested variable "api.nodes" to the inputs',
+															then.itShouldUpdateTheConfigNestedVariableToTheInputs,
+														);
+														Then(
+															'it should write the updated config to the config file',
+															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+														);
+														Then(
+															'it should resolve to an object with message "Successfully set api.nodes to ."',
+															then.itShouldResolveToAnObjectWithMessage,
+														);
+													},
+												);
+											},
+										);
+										Given(
+											'Vorpal is in interactive mode',
+											given.vorpalIsInInteractiveMode,
+											() => {
+												When(
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
+													() => {
+														Then(
+															'it should update the config nested variable "api.nodes" to the inputs',
+															then.itShouldUpdateTheConfigNestedVariableToTheInputs,
+														);
+														Then(
+															'it should write the updated config to the config file',
+															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+														);
+														Then(
+															'it should resolve to an object with message "Successfully set api.nodes to ."',
+															then.itShouldResolveToAnObjectWithMessage,
+														);
+													},
+												);
+											},
+										);
+									},
+								);
+							});
+						});
 						Given('a variable "api.network"', given.aVariable, () => {
 							Given('an unknown value "xxx"', given.anUnknownValue, () => {
 								When(
-									'the action is called with the variable and the value',
-									when.theActionIsCalledWithTheVariableAndTheValue,
+									'the action is called with the variable and the inputs',
+									when.theActionIsCalledWithTheVariableAndTheInputs,
 									() => {
 										Then(
 											'it should reject with validation error and message "Value must be a hex string with 64 characters, or one of main, test or beta."',
@@ -616,12 +790,12 @@ describe('set command', () => {
 								);
 							});
 							Given(
-								'a value "ed14889723f24ecc54871d058d98ce91ff2f97"',
-								given.aValue,
+								'inputs "ed14889723f24ecc54871d058d98ce91ff2f97"',
+								given.inputs,
 								() => {
 									When(
-										'the action is called with the variable and the value',
-										when.theActionIsCalledWithTheVariableAndTheValue,
+										'the action is called with the variable and the inputs',
+										when.theActionIsCalledWithTheVariableAndTheInputs,
 										() => {
 											Then(
 												'it should reject with validation error and message "Value must be a hex string with 64 characters, or one of main, test or beta."',
@@ -632,12 +806,12 @@ describe('set command', () => {
 								},
 							);
 							Given(
-								'a value "ed14889723f24ecc54871d058xxxxxxxxxxxxxxxxxxxxxxxxxba2b7b70ad2500"',
-								given.aValue,
+								'inputs "ed14889723f24ecc54871d058xxxxxxxxxxxxxxxxxxxxxxxxxba2b7b70ad2500"',
+								given.inputs,
 								() => {
 									When(
-										'the action is called with the variable and the value',
-										when.theActionIsCalledWithTheVariableAndTheValue,
+										'the action is called with the variable and the inputs',
+										when.theActionIsCalledWithTheVariableAndTheInputs,
 										() => {
 											Then(
 												'it should reject with validation error and message "Value must be a hex string with 64 characters, or one of main, test or beta."',
@@ -647,7 +821,7 @@ describe('set command', () => {
 									);
 								},
 							);
-							Given('a value "main"', given.aValue, () => {
+							Given('inputs "main"', given.inputs, () => {
 								Given(
 									'the config file can be written',
 									given.theConfigFileCanBeWritten,
@@ -657,12 +831,12 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
-															'it should update the config nested variable "api.network" to the value',
-															then.itShouldUpdateTheConfigNestedVariableToTheValue,
+															'it should update the config nested variable "api.network" to the first inputs',
+															then.itShouldUpdateTheConfigNestedVariableToTheFirstInputs,
 														);
 														Then(
 															'it should write the updated config to the config file',
@@ -681,12 +855,12 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
-															'it should update the config nested variable "api.network" to the value',
-															then.itShouldUpdateTheConfigNestedVariableToTheValue,
+															'it should update the config nested variable "api.network" to the first inputs',
+															then.itShouldUpdateTheConfigNestedVariableToTheFirstInputs,
 														);
 														Then(
 															'it should write the updated config to the config file',
@@ -703,7 +877,7 @@ describe('set command', () => {
 									},
 								);
 							});
-							Given('a value "test"', given.aValue, () => {
+							Given('inputs "test"', given.inputs, () => {
 								Given(
 									'the config file can be written',
 									given.theConfigFileCanBeWritten,
@@ -713,12 +887,12 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
-															'it should update the config nested variable "api.network" to the value',
-															then.itShouldUpdateTheConfigNestedVariableToTheValue,
+															'it should update the config nested variable "api.network" to the first inputs',
+															then.itShouldUpdateTheConfigNestedVariableToTheFirstInputs,
 														);
 														Then(
 															'it should write the updated config to the config file',
@@ -737,12 +911,12 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
-															'it should update the config nested variable "api.network" to the value',
-															then.itShouldUpdateTheConfigNestedVariableToTheValue,
+															'it should update the config nested variable "api.network" to the first inputs',
+															then.itShouldUpdateTheConfigNestedVariableToTheFirstInputs,
 														);
 														Then(
 															'it should write the updated config to the config file',
@@ -759,7 +933,7 @@ describe('set command', () => {
 									},
 								);
 							});
-							Given('a value "beta"', given.aValue, () => {
+							Given('inputs "beta"', given.inputs, () => {
 								Given(
 									'the config file can be written',
 									given.theConfigFileCanBeWritten,
@@ -769,12 +943,12 @@ describe('set command', () => {
 											given.vorpalIsInNonInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
-															'it should update the config nested variable "api.network" to the value',
-															then.itShouldUpdateTheConfigNestedVariableToTheValue,
+															'it should update the config nested variable "api.network" to the first inputs',
+															then.itShouldUpdateTheConfigNestedVariableToTheFirstInputs,
 														);
 														Then(
 															'it should write the updated config to the config file',
@@ -793,12 +967,12 @@ describe('set command', () => {
 											given.vorpalIsInInteractiveMode,
 											() => {
 												When(
-													'the action is called with the variable and the value',
-													when.theActionIsCalledWithTheVariableAndTheValue,
+													'the action is called with the variable and the inputs',
+													when.theActionIsCalledWithTheVariableAndTheInputs,
 													() => {
 														Then(
-															'it should update the config nested variable "api.network" to the value',
-															then.itShouldUpdateTheConfigNestedVariableToTheValue,
+															'it should update the config nested variable "api.network" to the first inputs',
+															then.itShouldUpdateTheConfigNestedVariableToTheFirstInputs,
 														);
 														Then(
 															'it should write the updated config to the config file',
@@ -816,8 +990,8 @@ describe('set command', () => {
 								);
 							});
 							Given(
-								'a value "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"',
-								given.aValue,
+								'inputs "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"',
+								given.inputs,
 								() => {
 									Given(
 										'the config file cannot be written',
@@ -828,8 +1002,8 @@ describe('set command', () => {
 												given.vorpalIsInNonInteractiveMode,
 												() => {
 													When(
-														'the action is called with the variable and the value',
-														when.theActionIsCalledWithTheVariableAndTheValue,
+														'the action is called with the variable and the inputs',
+														when.theActionIsCalledWithTheVariableAndTheInputs,
 														() => {
 															Then(
 																'it should reject with file system error and message "Config file could not be written: your changes will not be persisted."',
@@ -844,12 +1018,12 @@ describe('set command', () => {
 												given.vorpalIsInInteractiveMode,
 												() => {
 													When(
-														'the action is called with the variable and the value',
-														when.theActionIsCalledWithTheVariableAndTheValue,
+														'the action is called with the variable and the inputs',
+														when.theActionIsCalledWithTheVariableAndTheInputs,
 														() => {
 															Then(
-																'it should update the config nested variable "api.network" to the value',
-																then.itShouldUpdateTheConfigNestedVariableToTheValue,
+																'it should update the config nested variable "api.network" to the first inputs',
+																then.itShouldUpdateTheConfigNestedVariableToTheFirstInputs,
 															);
 															Then(
 																'it should resolve to an object with warning "Config file could not be written: your changes will not be persisted."',
@@ -874,12 +1048,12 @@ describe('set command', () => {
 												given.vorpalIsInNonInteractiveMode,
 												() => {
 													When(
-														'the action is called with the variable and the value',
-														when.theActionIsCalledWithTheVariableAndTheValue,
+														'the action is called with the variable and the inputs',
+														when.theActionIsCalledWithTheVariableAndTheInputs,
 														() => {
 															Then(
-																'it should update the config nested variable "api.network" to the value',
-																then.itShouldUpdateTheConfigNestedVariableToTheValue,
+																'it should update the config nested variable "api.network" to the first inputs',
+																then.itShouldUpdateTheConfigNestedVariableToTheFirstInputs,
 															);
 															Then(
 																'it should write the updated config to the config file',
@@ -898,12 +1072,12 @@ describe('set command', () => {
 												given.vorpalIsInInteractiveMode,
 												() => {
 													When(
-														'the action is called with the variable and the value',
-														when.theActionIsCalledWithTheVariableAndTheValue,
+														'the action is called with the variable and the inputs',
+														when.theActionIsCalledWithTheVariableAndTheInputs,
 														() => {
 															Then(
-																'it should update the config nested variable "api.network" to the value',
-																then.itShouldUpdateTheConfigNestedVariableToTheValue,
+																'it should update the config nested variable "api.network" to the first inputs',
+																then.itShouldUpdateTheConfigNestedVariableToTheFirstInputs,
 															);
 															Then(
 																'it should write the updated config to the config file',

--- a/test/specs/utils/api.js
+++ b/test/specs/utils/api.js
@@ -23,8 +23,8 @@ describe('API util', () => {
 		given.aConfigWithAPINetworkSetTo,
 		() => {
 			Given(
-				'a config with "api.node" set to "http://localhost:4000"',
-				given.aConfigWithAPINodeSetTo,
+				'a config with "api.nodes" set to "http://localhost:4000"',
+				given.aConfigWithAPINodesSetTo,
 				() => {
 					When(
 						'a API Client instance is created',
@@ -53,8 +53,8 @@ describe('API util', () => {
 		given.aConfigWithAPINetworkSetTo,
 		() => {
 			Given(
-				'a config with "api.node" set to "http://localhost:4000"',
-				given.aConfigWithAPINodeSetTo,
+				'a config with "api.nodes" set to "http://localhost:4000"',
+				given.aConfigWithAPINodesSetTo,
 				() => {
 					When(
 						'a API Client instance is created',
@@ -77,8 +77,8 @@ describe('API util', () => {
 				},
 			);
 			Given(
-				'a config with "api.node" set to ""',
-				given.aConfigWithAPINodeSetTo,
+				'a config with "api.nodes" set to ""',
+				given.aConfigWithAPINodesSetTo,
 				() => {
 					When(
 						'a API Client instance is created',
@@ -107,8 +107,8 @@ describe('API util', () => {
 		given.aConfigWithAPINetworkSetTo,
 		() => {
 			Given(
-				'a config with "api.node" set to "http://localhost:4000"',
-				given.aConfigWithAPINodeSetTo,
+				'a config with "api.nodes" set to "http://localhost:4000"',
+				given.aConfigWithAPINodesSetTo,
 				() => {
 					When(
 						'a API Client instance is created',

--- a/test/steps/api/2_when.js
+++ b/test/steps/api/2_when.js
@@ -14,18 +14,7 @@
  *
  */
 import getAPIClient from '../../../src/utils/api';
-import { getFirstBoolean, getFirstQuotedString } from '../utils';
 
 export function aLiskAPIInstanceIsCreated() {
 	this.test.ctx.liskAPIInstance = getAPIClient();
-}
-
-export function aLiskAPIInstanceIsCreatedWithAnInputBooleanOf() {
-	const override = getFirstBoolean(this.test.parent.title);
-	this.test.ctx.liskAPIInstance = getAPIClient(override);
-}
-
-export function aLiskAPIInstanceIsCreatedWithAnInputOf() {
-	const override = getFirstQuotedString(this.test.parent.title);
-	this.test.ctx.liskAPIInstance = getAPIClient(override);
 }

--- a/test/steps/config/1_given.js
+++ b/test/steps/config/1_given.js
@@ -55,7 +55,7 @@ export function aConfigWithJsonSetTo() {
 
 export function aConfigWithAPINodesSetTo() {
 	const nodes = getQuotedStrings(this.test.parent.title).slice(1);
-	const { api } = currentConfig.default || {};
+	const { api } = currentConfig.default;
 	api.nodes = nodes;
 	const config = { api };
 
@@ -65,7 +65,7 @@ export function aConfigWithAPINodesSetTo() {
 
 export function aConfigWithAPINetworkSetTo() {
 	const network = getQuotedStrings(this.test.parent.title)[1];
-	const { api } = currentConfig.default || {};
+	const { api } = currentConfig.default;
 	api.network = network;
 	const config = { api };
 

--- a/test/steps/config/1_given.js
+++ b/test/steps/config/1_given.js
@@ -53,10 +53,10 @@ export function aConfigWithJsonSetTo() {
 	this.test.ctx.config = config;
 }
 
-export function aConfigWithAPINodeSetTo() {
-	const node = getQuotedStrings(this.test.parent.title)[1];
+export function aConfigWithAPINodesSetTo() {
+	const nodes = getQuotedStrings(this.test.parent.title).slice(1);
 	const { api } = currentConfig.default || {};
-	api.node = node;
+	api.nodes = nodes;
 	const config = { api };
 
 	currentConfig.default = config;

--- a/test/steps/config/3_then.js
+++ b/test/steps/config/3_then.js
@@ -16,32 +16,42 @@
 import { getFirstQuotedString, getFirstBoolean } from '../utils';
 import { logError, logWarning } from '../../../src/utils/print';
 
-export function itShouldUpdateTheConfigVariableToTheFirstInputs() {
-	const { config, inputs } = this.test.ctx;
+export function itShouldUpdateTheConfigVariableToTheFirstValue() {
+	const { config, values } = this.test.ctx;
 	const variable = getFirstQuotedString(this.test.title);
 	return expect(config)
 		.to.have.property(variable)
-		.equal(inputs[0]);
+		.equal(values[0]);
 }
 
-export function itShouldUpdateTheConfigNestedVariableToTheFirstInputs() {
-	const { config, inputs } = this.test.ctx;
+export function itShouldUpdateTheConfigNestedVariableToTheFirstValue() {
+	const { config, values } = this.test.ctx;
 	const nestedVariable = getFirstQuotedString(this.test.title).split('.');
 	const configValue = nestedVariable.reduce(
 		(currentObject, nextKey) => currentObject[nextKey],
 		config,
 	);
-	return expect(configValue).to.equal(inputs[0]);
+	return expect(configValue).to.equal(values[0]);
 }
 
-export function itShouldUpdateTheConfigNestedVariableToTheInputs() {
-	const { config, inputs } = this.test.ctx;
+export function itShouldUpdateTheConfigNestedVariableToTheValues() {
+	const { config, values } = this.test.ctx;
 	const nestedVariable = getFirstQuotedString(this.test.title).split('.');
 	const configValue = nestedVariable.reduce(
 		(currentObject, nextKey) => currentObject[nextKey],
 		config,
 	);
-	return expect(configValue).to.equal(inputs);
+	return expect(configValue).to.equal(values);
+}
+
+export function itShouldUpdateTheConfigNestedVariableToEmptyArray() {
+	const { config } = this.test.ctx;
+	const nestedVariable = getFirstQuotedString(this.test.title).split('.');
+	const configValue = nestedVariable.reduce(
+		(currentObject, nextKey) => currentObject[nextKey],
+		config,
+	);
+	return expect(configValue).to.eql([]);
 }
 
 export function itShouldUpdateTheConfigVariableToBoolean() {

--- a/test/steps/config/3_then.js
+++ b/test/steps/config/3_then.js
@@ -16,22 +16,32 @@
 import { getFirstQuotedString, getFirstBoolean } from '../utils';
 import { logError, logWarning } from '../../../src/utils/print';
 
-export function itShouldUpdateTheConfigVariableToTheValue() {
-	const { config, value } = this.test.ctx;
+export function itShouldUpdateTheConfigVariableToTheFirstInputs() {
+	const { config, inputs } = this.test.ctx;
 	const variable = getFirstQuotedString(this.test.title);
 	return expect(config)
 		.to.have.property(variable)
-		.equal(value);
+		.equal(inputs[0]);
 }
 
-export function itShouldUpdateTheConfigNestedVariableToTheValue() {
-	const { value, config } = this.test.ctx;
+export function itShouldUpdateTheConfigNestedVariableToTheFirstInputs() {
+	const { config, inputs } = this.test.ctx;
 	const nestedVariable = getFirstQuotedString(this.test.title).split('.');
 	const configValue = nestedVariable.reduce(
 		(currentObject, nextKey) => currentObject[nextKey],
 		config,
 	);
-	return expect(configValue).to.equal(value);
+	return expect(configValue).to.equal(inputs[0]);
+}
+
+export function itShouldUpdateTheConfigNestedVariableToTheInputs() {
+	const { config, inputs } = this.test.ctx;
+	const nestedVariable = getFirstQuotedString(this.test.title).split('.');
+	const configValue = nestedVariable.reduce(
+		(currentObject, nextKey) => currentObject[nextKey],
+		config,
+	);
+	return expect(configValue).to.equal(inputs);
 }
 
 export function itShouldUpdateTheConfigVariableToBoolean() {

--- a/test/steps/files/1_given.js
+++ b/test/steps/files/1_given.js
@@ -183,7 +183,7 @@ export function theFileIsValidJSON() {
 		json: true,
 		api: {
 			network: 'beta',
-			node: ['http://localhost:4000'],
+			nodes: ['http://localhost:4000'],
 		},
 	};
 

--- a/test/steps/files/1_given.js
+++ b/test/steps/files/1_given.js
@@ -182,8 +182,8 @@ export function theFileIsValidJSON() {
 		name: 'custom-name',
 		json: true,
 		api: {
-			testnet: true,
-			node: 'my-node',
+			network: 'beta',
+			node: ['http://localhost:4000'],
 		},
 	};
 

--- a/test/steps/inputs/1_given.js
+++ b/test/steps/inputs/1_given.js
@@ -163,6 +163,10 @@ export function inputs() {
 	this.test.ctx.inputs = getQuotedStrings(this.test.parent.title);
 }
 
+export function values() {
+	this.test.ctx.values = getQuotedStrings(this.test.parent.title);
+}
+
 export function anInput() {
 	const input = getFirstQuotedString(this.test.parent.title);
 	this.test.ctx.input = input;

--- a/test/steps/utils.js
+++ b/test/steps/utils.js
@@ -49,7 +49,9 @@ export const getFirstQuotedString = title => title.match(regExpQuotes)[1];
 
 export const getQuotedStrings = title => {
 	const globalRegExp = new RegExp(regExpQuotes, 'g');
-	return title.match(globalRegExp).map(match => match.match(regExpQuotes)[1]);
+	return (title.match(globalRegExp) || []).map(
+		match => match.match(regExpQuotes)[1],
+	);
 };
 
 export const getFirstNumber = title => Number(title.match(regExpNumbers)[0]);

--- a/test/steps/vorpal/2_when.js
+++ b/test/steps/vorpal/2_when.js
@@ -219,6 +219,13 @@ export function theActionIsCalledWithTheVariableAndTheInputs() {
 	return returnValue.catch(e => e);
 }
 
+export function theActionIsCalledWithTheVariableAndTheValues() {
+	const { action, variable, values } = this.test.ctx;
+	const returnValue = action({ variable, values });
+	this.test.ctx.returnValue = returnValue;
+	return returnValue.catch(e => e);
+}
+
 export function theActionIsCalledWithTheOptions() {
 	const { action, options } = this.test.ctx;
 	const returnValue = action({ options });

--- a/test/steps/vorpal/2_when.js
+++ b/test/steps/vorpal/2_when.js
@@ -212,9 +212,9 @@ export function theActionIsCalledWithTheTypeTheInputAndTheOptions() {
 	return returnValue.catch(e => e);
 }
 
-export function theActionIsCalledWithTheVariableAndTheValue() {
-	const { action, variable, value } = this.test.ctx;
-	const returnValue = action({ variable, value });
+export function theActionIsCalledWithTheVariableAndTheInputs() {
+	const { action, variable, inputs } = this.test.ctx;
+	const returnValue = action({ variable, inputs });
 	this.test.ctx.returnValue = returnValue;
 	return returnValue.catch(e => e);
 }

--- a/test/steps/vorpal/2_when.js
+++ b/test/steps/vorpal/2_when.js
@@ -212,13 +212,6 @@ export function theActionIsCalledWithTheTypeTheInputAndTheOptions() {
 	return returnValue.catch(e => e);
 }
 
-export function theActionIsCalledWithTheVariableAndTheInputs() {
-	const { action, variable, inputs } = this.test.ctx;
-	const returnValue = action({ variable, inputs });
-	this.test.ctx.returnValue = returnValue;
-	return returnValue.catch(e => e);
-}
-
 export function theActionIsCalledWithTheVariableAndTheValues() {
 	const { action, variable, values } = this.test.ctx;
 	const returnValue = action({ variable, values });


### PR DESCRIPTION
### What was the problem?
Config file didn't have options to set multiple nodes, while APIClient supports multiple nodes.

### How did I fix it?
Change `api.node` on config to `api.nodes`.

### How to test it?
```
set api.nodes http://localhost:4000 http://localhost:4001
```

### Review checklist

* The PR solves #481 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
