### PR TITLE
Correct set command error message - Closes #498

### DIFF
--- a/src/commands/set.js
+++ b/src/commands/set.js
@@ -57,7 +57,7 @@ const setNestedConfigProperty = newValue => (
 			throw new ValidationError(
 				`Config file could not be written: property '${dotNotationArray.join(
 					'.',
-				)}' was not found. It looks like your configuration file is corrupted. Please check the file or run 'lisky clean' to remove it (a fresh default configuration file will be created when you run Lisky again).`,
+				)}' was not found. It looks like your configuration file is corrupted. Please check the file at ${configFilePath} or remove it (a fresh default configuration file will be created when you run Lisky again).`,
 			);
 		}
 		// eslint-disable-next-line no-param-reassign

--- a/test/specs/commands/set.js
+++ b/test/specs/commands/set.js
@@ -38,7 +38,9 @@ describe('set command', () => {
 										when.theActionIsCalledWithTheVariableAndTheValues,
 										() => {
 											Then(
-												"it should reject with validation error and message \"Config file could not be written: property 'api.nodes' was not found. It looks like your configuration file is corrupted. Please check the file or run 'lisky clean' to remove it (a fresh default configuration file will be created when you run Lisky again).\"",
+												`it should reject with validation error and message "Config file could not be written: property 'api.nodes' was not found. It looks like your configuration file is corrupted. Please check the file at ${
+													process.env.LISKY_CONFIG_DIR
+												}/config.json or remove it (a fresh default configuration file will be created when you run Lisky again)."`,
 												then.itShouldRejectWithValidationErrorAndMessage,
 											);
 										},


### PR DESCRIPTION
### What was the problem?

An error message for the `set` command was misleading.

### How did I fix it?

I corrected the message to be more helpful.

### How to test it?

1. Corrupt your config file by removing a key.
2. Start Lisky.
3. Set the missing key.
4. Read the error message (and follow the instructions).

### Review checklist

* The PR solves #498
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
