### PR TITLE
Validate config on load - Closes #493

### DIFF
--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -57,24 +57,17 @@ const attemptToCreateFile = path => {
 	return attemptCallWithWarning(fn, path);
 };
 
-const checkReadAccess = path => {
-	const fn = fs.accessSync.bind(null, path, fs.constants.R_OK);
-	const errorCode = 1;
-	const errorMessage = `Could not read config file. Please check permissions for ${path} or delete the file so we can create a new one from defaults.`;
-	return attemptCallWithError(fn, errorCode, errorMessage);
-};
-
 const checkLockfile = path => {
 	const fn = lockfile.lockSync.bind(null, path);
-	const errorCode = 3;
+	const errorCode = 2;
 	const errorMessage = `Config lockfile at ${lockfilePath} found. Are you running Lisky in another process?`;
 	return attemptCallWithError(fn, errorCode, errorMessage);
 };
 
 const attemptToReadJSONFile = path => {
 	const fn = readJSONSync.bind(null, path);
-	const errorCode = 2;
-	const errorMessage = `Config file is not valid JSON. Please check ${path} or delete the file so we can create a new one from defaults.`;
+	const errorCode = 1;
+	const errorMessage = `Config file cannot be read or is not valid JSON. Please check ${path} or delete the file so we can create a new one from defaults.`;
 	return attemptCallWithError(fn, errorCode, errorMessage);
 };
 
@@ -91,8 +84,6 @@ const getConfig = () => {
 	if (!process.env.EXEC_FILE_CHILD) {
 		checkLockfile(lockfilePath);
 	}
-
-	checkReadAccess(configFilePath);
 
 	return attemptToReadJSONFile(configFilePath);
 };

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -40,12 +40,12 @@ const attemptCallWithWarning = (fn, path) => {
 	}
 };
 
-const attemptCallWithError = (fn, errorCode, errorMessage) => {
+const attemptCallWithError = (fn, errorMessage) => {
 	try {
 		return fn();
 	} catch (_) {
 		logger.error(errorMessage);
-		return process.exit(errorCode);
+		return process.exit(1);
 	}
 };
 
@@ -61,16 +61,14 @@ const attemptToCreateFile = path => {
 
 const checkLockfile = path => {
 	const fn = lockfile.lockSync.bind(null, path);
-	const errorCode = 2;
 	const errorMessage = `Config lockfile at ${lockfilePath} found. Are you running Lisky in another process?`;
-	return attemptCallWithError(fn, errorCode, errorMessage);
+	return attemptCallWithError(fn, errorMessage);
 };
 
 const attemptToReadJSONFile = path => {
 	const fn = readJSONSync.bind(null, path);
-	const errorCode = 1;
 	const errorMessage = `Config file cannot be read or is not valid JSON. Please check ${path} or delete the file so we can create a new one from defaults.`;
-	return attemptCallWithError(fn, errorCode, errorMessage);
+	return attemptCallWithError(fn, errorMessage);
 };
 
 const attemptToValidateConfig = (config, path) => {
@@ -81,9 +79,8 @@ const attemptToValidateConfig = (config, path) => {
 				throw new ValidationError(`Key ${key} not found in config file.`);
 			}
 		});
-	const errorCode = 3;
 	const errorMessage = `Config file seems to be corrupted: missing required keys. Please check ${path} or delete the file so we can create a new one from defaults.`;
-	return attemptCallWithError(fn, errorCode, errorMessage);
+	return attemptCallWithError(fn, errorMessage);
 };
 
 const getConfig = () => {

--- a/test/specs/utils/config.js
+++ b/test/specs/utils/config.js
@@ -146,7 +146,7 @@ describe('config util', () => {
 														then.theUserShouldBeInformedThatAConfigLockfileWasFoundAtPath,
 													);
 													Then(
-														'the process should exit with error code "2"',
+														'the process should exit with error code "1"',
 														then.theProcessShouldExitWithErrorCode,
 													);
 													Then(
@@ -310,7 +310,7 @@ describe('config util', () => {
 																		then.theUserShouldBeInformedThatTheConfigFileIsCorrupted,
 																	);
 																	Then(
-																		'the process should exit with error code "3"',
+																		'the process should exit with error code "1"',
 																		then.theProcessShouldExitWithErrorCode,
 																	);
 																	Then(

--- a/test/specs/utils/config.js
+++ b/test/specs/utils/config.js
@@ -188,8 +188,8 @@ describe('config util', () => {
 																},
 															);
 															Given(
-																'the config file is valid JSON',
-																given.theFileIsValidJSON,
+																'the config file is valid',
+																given.theFileIsValid,
 																() => {
 																	Given(
 																		'the config file cannot be written',
@@ -296,46 +296,46 @@ describe('config util', () => {
 														},
 													);
 													Given(
-														'the config file is valid JSON',
-														given.theFileIsValidJSON,
+														'the config file is missing required keys',
+														given.theFileIsMissingRequiredKeys,
 														() => {
-															Given(
-																'the config file cannot be written',
-																given.theFileCannotBeWritten,
+															When(
+																'the config is loaded',
+																when.theConfigIsLoaded,
 																() => {
-																	When(
-																		'the config is loaded',
-																		when.theConfigIsLoaded,
-																		() => {
-																			Then(
-																				'the config file should not be written',
-																				then.theConfigFileShouldNotBeWritten,
-																			);
-																			Then(
-																				'the user’s config should be exported',
-																				then.theUsersConfigShouldBeExported,
-																			);
-																		},
+																	Then(
+																		`the user should be informed that the config file at "${
+																			process.env.LISKY_CONFIG_DIR
+																		}/config.json" is corrupted`,
+																		then.theUserShouldBeInformedThatTheConfigFileIsCorrupted,
+																	);
+																	Then(
+																		'the process should exit with error code "3"',
+																		then.theProcessShouldExitWithErrorCode,
+																	);
+																	Then(
+																		'the config file should not be written',
+																		then.theConfigFileShouldNotBeWritten,
 																	);
 																},
 															);
-															Given(
-																'the config file can be written',
-																given.theFileCanBeWritten,
+														},
+													);
+													Given(
+														'the config file is valid',
+														given.theFileIsValid,
+														() => {
+															When(
+																'the config is loaded',
+																when.theConfigIsLoaded,
 																() => {
-																	When(
-																		'the config is loaded',
-																		when.theConfigIsLoaded,
-																		() => {
-																			Then(
-																				'the config file should not be written',
-																				then.theConfigFileShouldNotBeWritten,
-																			);
-																			Then(
-																				'the user’s config should be exported',
-																				then.theUsersConfigShouldBeExported,
-																			);
-																		},
+																	Then(
+																		'the config file should not be written',
+																		then.theConfigFileShouldNotBeWritten,
+																	);
+																	Then(
+																		'the user’s config should be exported',
+																		then.theUsersConfigShouldBeExported,
 																	);
 																},
 															);

--- a/test/specs/utils/config.js
+++ b/test/specs/utils/config.js
@@ -132,30 +132,6 @@ describe('config util', () => {
 								given.theFileDoesExist,
 								() => {
 									Given(
-										'the config file is not readable',
-										given.theFileCannotBeRead,
-										() => {
-											When(
-												'the config is loaded',
-												when.theConfigIsLoaded,
-												() => {
-													Then(
-														'the user should be informed that the config file permissions are incorrect',
-														then.theUserShouldBeInformedThatTheConfigFilePermissionsAreIncorrect,
-													);
-													Then(
-														'the process should exit with error code "1"',
-														then.theProcessShouldExitWithErrorCode,
-													);
-													Then(
-														'the config file should not be written',
-														then.theConfigFileShouldNotBeWritten,
-													);
-												},
-											);
-										},
-									);
-									Given(
 										'there is a config lockfile',
 										given.thereIsAConfigLockfile,
 										() => {
@@ -170,7 +146,7 @@ describe('config util', () => {
 														then.theUserShouldBeInformedThatAConfigLockfileWasFoundAtPath,
 													);
 													Then(
-														'the process should exit with error code "3"',
+														'the process should exit with error code "2"',
 														then.theProcessShouldExitWithErrorCode,
 													);
 													Then(
@@ -196,11 +172,11 @@ describe('config util', () => {
 																		when.theConfigIsLoaded,
 																		() => {
 																			Then(
-																				'the user should be informed that the config file is not valid JSON',
-																				then.theUserShouldBeInformedThatTheConfigFileIsNotValidJSON,
+																				'the user should be informed that the config file cannot be read or is not valid JSON',
+																				then.theUserShouldBeInformedThatTheConfigFileCannotBeReadOrIsNotValidJSON,
 																			);
 																			Then(
-																				'the process should exit with error code "2"',
+																				'the process should exit with error code "1"',
 																				then.theProcessShouldExitWithErrorCode,
 																			);
 																			Then(
@@ -268,6 +244,30 @@ describe('config util', () => {
 										given.thereIsNoConfigLockfile,
 										() => {
 											Given(
+												'the config file cannot be read',
+												given.theFileCannotBeRead,
+												() => {
+													When(
+														'the config is loaded',
+														when.theConfigIsLoaded,
+														() => {
+															Then(
+																'the user should be informed that the config file cannot be read or is not valid JSON',
+																then.theUserShouldBeInformedThatTheConfigFileCannotBeReadOrIsNotValidJSON,
+															);
+															Then(
+																'the process should exit with error code "1"',
+																then.theProcessShouldExitWithErrorCode,
+															);
+															Then(
+																'the config file should not be written',
+																then.theConfigFileShouldNotBeWritten,
+															);
+														},
+													);
+												},
+											);
+											Given(
 												'the config file can be read',
 												given.theFileCanBeRead,
 												() => {
@@ -280,11 +280,11 @@ describe('config util', () => {
 																when.theConfigIsLoaded,
 																() => {
 																	Then(
-																		'the user should be informed that the config file is not valid JSON',
-																		then.theUserShouldBeInformedThatTheConfigFileIsNotValidJSON,
+																		'the user should be informed that the config file cannot be read or is not valid JSON',
+																		then.theUserShouldBeInformedThatTheConfigFileCannotBeReadOrIsNotValidJSON,
 																	);
 																	Then(
-																		'the process should exit with error code "2"',
+																		'the process should exit with error code "1"',
 																		then.theProcessShouldExitWithErrorCode,
 																	);
 																	Then(

--- a/test/steps/config/3_then.js
+++ b/test/steps/config/3_then.js
@@ -84,17 +84,10 @@ export function theUserShouldBeWarnedThatTheConfigWillNotBePersisted() {
 	);
 }
 
-export function theUserShouldBeInformedThatTheConfigFilePermissionsAreIncorrect() {
+export function theUserShouldBeInformedThatTheConfigFileCannotBeReadOrIsNotValidJSON() {
 	const { filePath } = this.test.ctx;
 	return expect(logger.error).to.be.calledWithExactly(
-		`Could not read config file. Please check permissions for ${filePath} or delete the file so we can create a new one from defaults.`,
-	);
-}
-
-export function theUserShouldBeInformedThatTheConfigFileIsNotValidJSON() {
-	const { filePath } = this.test.ctx;
-	return expect(logger.error).to.be.calledWithExactly(
-		`Config file is not valid JSON. Please check ${filePath} or delete the file so we can create a new one from defaults.`,
+		`Config file cannot be read or is not valid JSON. Please check ${filePath} or delete the file so we can create a new one from defaults.`,
 	);
 }
 

--- a/test/steps/config/3_then.js
+++ b/test/steps/config/3_then.js
@@ -97,3 +97,10 @@ export function theUserShouldBeInformedThatAConfigLockfileWasFoundAtPath() {
 		`Config lockfile at ${path} found. Are you running Lisky in another process?`,
 	);
 }
+
+export function theUserShouldBeInformedThatTheConfigFileIsCorrupted() {
+	const path = getFirstQuotedString(this.test.title);
+	return expect(logger.error).to.be.calledWithExactly(
+		`Config file seems to be corrupted: missing required keys. Please check ${path} or delete the file so we can create a new one from defaults.`,
+	);
+}

--- a/test/steps/files/1_given.js
+++ b/test/steps/files/1_given.js
@@ -177,7 +177,18 @@ export function theFileIsNotValidJSON() {
 	fsUtils.readJSONSync.throws('Invalid JSON');
 }
 
-export function theFileIsValidJSON() {
+export function theFileIsMissingRequiredKeys() {
+	const userConfig = {
+		name: 'custom-name',
+		json: true,
+	};
+
+	this.test.ctx.userConfig = userConfig;
+
+	fsUtils.readJSONSync.returns(userConfig);
+}
+
+export function theFileIsValid() {
 	const userConfig = {
 		name: 'custom-name',
 		json: true,


### PR DESCRIPTION
### What was the problem?

Config files with missing keys would not prevent Lisk Commander from starting, and a crash could occur when using the `set` command later on.

### How did I fix it?

I added validation when the config is loaded.

### How to test it?

Start Lisk Commander with corrupted config files (or config files generated by pre 1.0.0 versions) and try `set`.

### Review checklist

* The PR solves #493 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
