### PR TITLE
Use LiskHQ cli-table2 dependency - Closes #503

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
 		"babel-polyfill": "=6.26.0",
 		"bip39": "=2.4.0",
 		"chalk": "=2.3.0",
-		"cli-table2":
-			"jamestalmage/cli-table2#187c6ae80b9d963c598d0cb3379153387bfb15c4",
+		"cli-table2": "LiskHQ/cli-table2#187c6ae80b9d963c598d0cb3379153387bfb15c4",
 		"lisk-js": "beta",
 		"lockfile": "=1.0.3",
 		"semver": "=5.5.0",


### PR DESCRIPTION
### What was the problem?

We were depending on somebody else's GitHub repo.

### How did I fix it?

Updated to LiskHQ's fork.

### How to test it?

`npm install`

### Review checklist

* The PR solves #503 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
