### PR TITLE
Add validation on api.nodes url

### DIFF
--- a/src/commands/set.js
+++ b/src/commands/set.js
@@ -39,7 +39,9 @@ const NETHASH_ERROR_MESSAGE =
 
 const URL_ERROR_MESSAGE = `Node URLs must include a supported protocol (${API_PROTOCOLS.map(
 	protocol => protocol.replace(':', ''),
-).toString()}) and a hostname. E.g. https://127.0.0.1:4000 or http://localhost.`;
+).join(
+	', ',
+)}) and a hostname. E.g. https://127.0.0.1:4000 or http://localhost.`;
 
 const writeConfigToFile = newConfig => {
 	try {

--- a/src/commands/set.js
+++ b/src/commands/set.js
@@ -15,7 +15,7 @@
  */
 import url from 'url';
 import lisk from 'lisk-js';
-import { CONFIG_VARIABLES, NETHASHES } from '../utils/constants';
+import { CONFIG_VARIABLES, NETHASHES, API_PROTOCOLS } from '../utils/constants';
 import config, { configFilePath } from '../utils/config';
 import { FileSystemError, ValidationError } from '../utils/error';
 import { writeJSONSync } from '../utils/fs';
@@ -37,7 +37,7 @@ const NETHASH_ERROR_MESSAGE =
 	'Value must be a hex string with 64 characters, or one of main, test or beta.';
 
 const URL_ERROR_MESSAGE =
-	'Value must have protocol and hostname, such as http://localhost:4000';
+	'Node URLs must include a protocol and a hostname. E.g. https://127.0.0.1:4000 or http://localhost.';
 const writeConfigToFile = newConfig => {
 	try {
 		writeJSONSync(configFilePath, newConfig);
@@ -110,7 +110,7 @@ const setBoolean = (dotNotation, value) => {
 const setArrayURL = (dotNotation, value, inputs) => {
 	inputs.forEach(input => {
 		const parsedURL = url.parse(input);
-		if (!parsedURL.protocol || !parsedURL.hostname) {
+		if (!API_PROTOCOLS.includes(parsedURL.protocol) || !parsedURL.hostname) {
 			throw new ValidationError(URL_ERROR_MESSAGE);
 		}
 	});

--- a/src/commands/set.js
+++ b/src/commands/set.js
@@ -13,6 +13,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import url from 'url';
 import lisk from 'lisk-js';
 import { CONFIG_VARIABLES, NETHASHES } from '../utils/constants';
 import config, { configFilePath } from '../utils/config';
@@ -35,6 +36,8 @@ const WRITE_FAIL_WARNING =
 const NETHASH_ERROR_MESSAGE =
 	'Value must be a hex string with 64 characters, or one of main, test or beta.';
 
+const URL_ERROR_MESSAGE =
+	'Value must have protocol and hostname, such as http://localhost:4000';
 const writeConfigToFile = newConfig => {
 	try {
 		writeJSONSync(configFilePath, newConfig);
@@ -104,8 +107,15 @@ const setBoolean = (dotNotation, value) => {
 	return setValue(dotNotation, newValue);
 };
 
-const setArrayString = (dotNotation, value, inputs) =>
-	setValue(dotNotation, inputs);
+const setArrayURL = (dotNotation, value, inputs) => {
+	inputs.forEach(input => {
+		const parsedURL = url.parse(input);
+		if (!parsedURL.protocol || !parsedURL.hostname) {
+			throw new ValidationError(URL_ERROR_MESSAGE);
+		}
+	});
+	return setValue(dotNotation, inputs);
+};
 
 const setNethash = (dotNotation, value) => {
 	if (
@@ -125,7 +135,7 @@ const setNethash = (dotNotation, value) => {
 };
 
 const handlers = {
-	'api.nodes': setArrayString,
+	'api.nodes': setArrayURL,
 	'api.network': setNethash,
 	json: setBoolean,
 	name: setValue,

--- a/src/commands/set.js
+++ b/src/commands/set.js
@@ -28,6 +28,7 @@ const description = `Sets configuration <variable> to [value(s)...]. Variables a
 	- set json true
 	- set name my_custom_lisky
 	- set api.network main
+	- set api.nodes https://127.0.0.1:4000,http://mynode.com:7000
 `;
 
 const WRITE_FAIL_WARNING =
@@ -36,8 +37,10 @@ const WRITE_FAIL_WARNING =
 const NETHASH_ERROR_MESSAGE =
 	'Value must be a hex string with 64 characters, or one of main, test or beta.';
 
-const URL_ERROR_MESSAGE =
-	'Node URLs must include a protocol and a hostname. E.g. https://127.0.0.1:4000 or http://localhost.';
+const URL_ERROR_MESSAGE = `Node URLs must include a supported protocol (${API_PROTOCOLS.map(
+	protocol => protocol.replace(':', ''),
+).toString()}) and a hostname. E.g. https://127.0.0.1:4000 or http://localhost.`;
+
 const writeConfigToFile = newConfig => {
 	try {
 		writeJSONSync(configFilePath, newConfig);
@@ -109,8 +112,8 @@ const setBoolean = (dotNotation, value) => {
 
 const setArrayURL = (dotNotation, value, inputs) => {
 	inputs.forEach(input => {
-		const parsedURL = url.parse(input);
-		if (!API_PROTOCOLS.includes(parsedURL.protocol) || !parsedURL.hostname) {
+		const { protocol, hostname } = url.parse(input);
+		if (!API_PROTOCOLS.includes(protocol) || !hostname) {
 			throw new ValidationError(URL_ERROR_MESSAGE);
 		}
 	});

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -48,6 +48,8 @@ export const CONFIG_VARIABLES = [
 	'pretty',
 ];
 
+export const API_PROTOCOLS = ['http:', 'https:'];
+
 export const NETHASHES = {
 	main: constants.MAINNET_NETHASH,
 	test: constants.TESTNET_NETHASH,

--- a/test/specs/commands/set.js
+++ b/test/specs/commands/set.js
@@ -32,7 +32,7 @@ describe('set command', () => {
 						given.aConfigWithUnknownProperties,
 						() => {
 							Given('a variable "api.nodes"', given.aVariable, () => {
-								Given('values "true"', given.values, () => {
+								Given('values "http://localhost"', given.values, () => {
 									When(
 										'the action is called with the variable and the values',
 										when.theActionIsCalledWithTheVariableAndTheValues,
@@ -605,8 +605,48 @@ describe('set command', () => {
 							});
 						});
 						Given('a variable "api.nodes"', given.aVariable, () => {
+							Given('values "localhost"', given.values, () => {
+								Given(
+									'the config file can be written',
+									given.theConfigFileCanBeWritten,
+									() => {
+										Given(
+											'Vorpal is in non-interactive mode',
+											given.vorpalIsInNonInteractiveMode,
+											() => {
+												When(
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
+													() => {
+														Then(
+															'it should reject with validation error and message "Value must have protocol and hostname, such as http://localhost:4000"',
+															then.itShouldRejectWithValidationErrorAndMessage,
+														);
+													},
+												);
+											},
+										);
+										Given(
+											'Vorpal is in interactive mode',
+											given.vorpalIsInInteractiveMode,
+											() => {
+												When(
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
+													() => {
+														Then(
+															'it should reject with validation error and message "Value must have protocol and hostname, such as http://localhost:4000"',
+															then.itShouldRejectWithValidationErrorAndMessage,
+														);
+													},
+												);
+											},
+										);
+									},
+								);
+							});
 							Given(
-								'values "localhost" and "http://127.0.0.1"',
+								'values "http://localhost:4000" and "http://127.0.0.1"',
 								given.values,
 								() => {
 									Given(
@@ -630,7 +670,7 @@ describe('set command', () => {
 																then.itShouldWriteTheUpdatedConfigToTheConfigFile,
 															);
 															Then(
-																'it should resolve to an object with message "Successfully set api.nodes to localhost,http://127.0.0.1."',
+																'it should resolve to an object with message "Successfully set api.nodes to http://localhost:4000,http://127.0.0.1."',
 																then.itShouldResolveToAnObjectWithMessage,
 															);
 														},
@@ -654,7 +694,7 @@ describe('set command', () => {
 																then.itShouldWriteTheUpdatedConfigToTheConfigFile,
 															);
 															Then(
-																'it should resolve to an object with message "Successfully set api.nodes to localhost,http://127.0.0.1."',
+																'it should resolve to an object with message "Successfully set api.nodes to http://localhost:4000,http://127.0.0.1."',
 																then.itShouldResolveToAnObjectWithMessage,
 															);
 														},

--- a/test/specs/commands/set.js
+++ b/test/specs/commands/set.js
@@ -619,7 +619,7 @@ describe('set command', () => {
 													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should reject with validation error and message "Node URLs must include a supported protocol (http,https) and a hostname. E.g. https://127.0.0.1:4000 or http://localhost."',
+															'it should reject with validation error and message "Node URLs must include a supported protocol (http, https) and a hostname. E.g. https://127.0.0.1:4000 or http://localhost."',
 															then.itShouldRejectWithValidationErrorAndMessage,
 														);
 													},
@@ -635,7 +635,7 @@ describe('set command', () => {
 													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should reject with validation error and message "Node URLs must include a supported protocol (http,https) and a hostname. E.g. https://127.0.0.1:4000 or http://localhost."',
+															'it should reject with validation error and message "Node URLs must include a supported protocol (http, https) and a hostname. E.g. https://127.0.0.1:4000 or http://localhost."',
 															then.itShouldRejectWithValidationErrorAndMessage,
 														);
 													},
@@ -659,7 +659,7 @@ describe('set command', () => {
 													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should reject with validation error and message "Node URLs must include a supported protocol (http,https) and a hostname. E.g. https://127.0.0.1:4000 or http://localhost."',
+															'it should reject with validation error and message "Node URLs must include a supported protocol (http, https) and a hostname. E.g. https://127.0.0.1:4000 or http://localhost."',
 															then.itShouldRejectWithValidationErrorAndMessage,
 														);
 													},
@@ -675,7 +675,7 @@ describe('set command', () => {
 													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should reject with validation error and message "Node URLs must include a supported protocol (http,https) and a hostname. E.g. https://127.0.0.1:4000 or http://localhost."',
+															'it should reject with validation error and message "Node URLs must include a supported protocol (http, https) and a hostname. E.g. https://127.0.0.1:4000 or http://localhost."',
 															then.itShouldRejectWithValidationErrorAndMessage,
 														);
 													},

--- a/test/specs/commands/set.js
+++ b/test/specs/commands/set.js
@@ -619,7 +619,7 @@ describe('set command', () => {
 													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should reject with validation error and message "Value must have protocol and hostname, such as http://localhost:4000"',
+															'it should reject with validation error and message "Node URLs must include a protocol and a hostname. E.g. https://127.0.0.1:4000 or http://localhost."',
 															then.itShouldRejectWithValidationErrorAndMessage,
 														);
 													},
@@ -635,7 +635,47 @@ describe('set command', () => {
 													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should reject with validation error and message "Value must have protocol and hostname, such as http://localhost:4000"',
+															'it should reject with validation error and message "Node URLs must include a protocol and a hostname. E.g. https://127.0.0.1:4000 or http://localhost."',
+															then.itShouldRejectWithValidationErrorAndMessage,
+														);
+													},
+												);
+											},
+										);
+									},
+								);
+							});
+							Given('values "localhost:4000"', given.values, () => {
+								Given(
+									'the config file can be written',
+									given.theConfigFileCanBeWritten,
+									() => {
+										Given(
+											'Vorpal is in non-interactive mode',
+											given.vorpalIsInNonInteractiveMode,
+											() => {
+												When(
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
+													() => {
+														Then(
+															'it should reject with validation error and message "Node URLs must include a protocol and a hostname. E.g. https://127.0.0.1:4000 or http://localhost."',
+															then.itShouldRejectWithValidationErrorAndMessage,
+														);
+													},
+												);
+											},
+										);
+										Given(
+											'Vorpal is in interactive mode',
+											given.vorpalIsInInteractiveMode,
+											() => {
+												When(
+													'the action is called with the variable and the values',
+													when.theActionIsCalledWithTheVariableAndTheValues,
+													() => {
+														Then(
+															'it should reject with validation error and message "Node URLs must include a protocol and a hostname. E.g. https://127.0.0.1:4000 or http://localhost."',
 															then.itShouldRejectWithValidationErrorAndMessage,
 														);
 													},

--- a/test/specs/commands/set.js
+++ b/test/specs/commands/set.js
@@ -619,7 +619,7 @@ describe('set command', () => {
 													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should reject with validation error and message "Node URLs must include a protocol and a hostname. E.g. https://127.0.0.1:4000 or http://localhost."',
+															'it should reject with validation error and message "Node URLs must include a supported protocol (http,https) and a hostname. E.g. https://127.0.0.1:4000 or http://localhost."',
 															then.itShouldRejectWithValidationErrorAndMessage,
 														);
 													},
@@ -635,7 +635,7 @@ describe('set command', () => {
 													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should reject with validation error and message "Node URLs must include a protocol and a hostname. E.g. https://127.0.0.1:4000 or http://localhost."',
+															'it should reject with validation error and message "Node URLs must include a supported protocol (http,https) and a hostname. E.g. https://127.0.0.1:4000 or http://localhost."',
 															then.itShouldRejectWithValidationErrorAndMessage,
 														);
 													},
@@ -659,7 +659,7 @@ describe('set command', () => {
 													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should reject with validation error and message "Node URLs must include a protocol and a hostname. E.g. https://127.0.0.1:4000 or http://localhost."',
+															'it should reject with validation error and message "Node URLs must include a supported protocol (http,https) and a hostname. E.g. https://127.0.0.1:4000 or http://localhost."',
 															then.itShouldRejectWithValidationErrorAndMessage,
 														);
 													},
@@ -675,7 +675,7 @@ describe('set command', () => {
 													when.theActionIsCalledWithTheVariableAndTheValues,
 													() => {
 														Then(
-															'it should reject with validation error and message "Node URLs must include a protocol and a hostname. E.g. https://127.0.0.1:4000 or http://localhost."',
+															'it should reject with validation error and message "Node URLs must include a supported protocol (http,https) and a hostname. E.g. https://127.0.0.1:4000 or http://localhost."',
 															then.itShouldRejectWithValidationErrorAndMessage,
 														);
 													},


### PR DESCRIPTION
### What was the problem?
There was no validation on `api.nodes` config set.

### How did I fix it?
Add a url parse and check at hostname and protocol exists.
- http://localhost:4000 <= ok
- http://localhost <= ok
- localhost <= not ok
- true <= not ok

### How to test it?
```
set api.nodes omg
set api.nodes localhost
set api.nodes http://localhost
set api.nodes http://localhost:3000
```

### Review checklist

* The PR solves #494 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
