### PR TITLE
Add verify transaction command - Closes #407

### DIFF
--- a/src/commands/verify_transaction.js
+++ b/src/commands/verify_transaction.js
@@ -1,0 +1,69 @@
+/*
+ * LiskHQ/lisky
+ * Copyright © 2017 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import transactions from '../utils/transactions';
+import { ValidationError } from '../utils/error';
+import { createCommand } from '../utils/helpers';
+import commonOptions from '../utils/options';
+
+const description = `Verify a transaction.
+
+	Examples:
+	- verify transaction '{"type":0,"amount":"100",...}'
+	- verify transaction --second-publickey 647aac1e2df8a5c870499d7ddc82236b1e10936977537a3844a6b05ea33f9ef6 '{"type":0,"amount":"100",...}'
+`;
+
+const getTransactionInput = ({ transaction, stdin, shouldUseStdIn }) => {
+	const hasStdIn = stdin && stdin[0];
+	if (shouldUseStdIn && !hasStdIn) {
+		throw new ValidationError('No transaction was provided.');
+	}
+	return shouldUseStdIn ? stdin[0] : transaction;
+};
+
+export const actionCreator = () => async ({ transaction, stdin, options }) => {
+	const shouldUseStdIn = !transaction;
+	const transactionInput = getTransactionInput({
+		transaction,
+		stdin,
+		shouldUseStdIn,
+	});
+	let transactionObject;
+	try {
+		transactionObject = JSON.parse(transactionInput);
+	} catch (error) {
+		throw new ValidationError(
+			'Could not parse transaction JSON. Did you use the `--json` option?',
+		);
+	}
+	const secondPublicKey = options['second-public-key'] || null;
+	const varified = transactions.utils.verifyTransaction(
+		transactionObject,
+		secondPublicKey,
+	);
+	return {
+		varified,
+	};
+};
+
+const verifyTransaction = createCommand({
+	command: 'verify transaction [transaction]',
+	description,
+	actionCreator,
+	options: [commonOptions.secondPublicKey],
+	errorPrefix: 'Could not verify transaction',
+});
+
+export default verifyTransaction;

--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -34,6 +34,15 @@ const secondPassphraseDescription = `Specifies a source for your second secret p
 	- --second-passphrase stdin (takes one line only)
 `;
 
+const secondPublicKeyDescription = `Specifies a source for your second public key. It is necessary to verify an transaction associated with second passphrase registered account.
+
+	Note: if both second public key and transaction are passed via stdin, the second public key must be the first line.
+
+	Examples:
+	- --second-public-key file:/path/to/my/second-public-key.txt
+	- --second-public-key stdin
+`;
+
 const passwordDescription = `Specifies a source for your secret password. Lisky will prompt you for input if this option is not set.
 
 	Source must be one of \`prompt\`, \`pass\`, \`env\`, \`file\` or \`stdin\`. For \`pass\`, \`env\` and \`file\` a corresponding identifier must also be provided.
@@ -78,6 +87,7 @@ const options = {
 		'-s, --second-passphrase <source>',
 		secondPassphraseDescription,
 	],
+	secondPublicKey: ['--second-public-key <source>', secondPublicKeyDescription],
 	password: ['-w, --password <source>', passwordDescription],
 	pretty: ['--pretty', prettyDescription],
 	table: ['-t, --table', tableDescription],


### PR DESCRIPTION
### Description
Adding verify transaction command.

### How to test it?
```
verify transaction '{"amount":"10000000000","recipientId":"123L","senderPublicKey":"caf0f4c00cf9240771975e42b6672c88a832f98f01825dda6e001e2aab0bc0cc","timestamp":61158273,"type":0,"fee":"10000000","recipientPublicKey":null,"asset":{},"sig
nature":"d71ae9842b2e0f44207808489746d3a5a1b93cdda23307c53b7d735a293b5847ec47c201a4fcbc8746a2397f026cbceb49ea6bce00f1f841077b848b89dc2008","id":"15250462192936083359"}'

create transaction transfer 100 123L --json | verify transaction --second-public-key caf0f4c00cf9240771975e42b6672c88a832f98f01825dda6e001e2aab0bc0cc
```

### Review checklist

* The PR solves #407 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
