### PR TITLE
Fix lockfile usage - Closes #529

### DIFF
--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -13,7 +13,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import currentConfig from '../utils/config';
+import { getConfig } from '../utils/config';
 import { createCommand } from '../utils/helpers';
 
 const description = `Prints the current configuration.
@@ -21,7 +21,7 @@ const description = `Prints the current configuration.
 	Example: config
 `;
 
-export const actionCreator = () => async () => currentConfig;
+export const actionCreator = () => async () => getConfig();
 
 const config = createCommand({
 	command: 'config',

--- a/src/commands/set.js
+++ b/src/commands/set.js
@@ -21,7 +21,7 @@ import { FileSystemError, ValidationError } from '../utils/error';
 import { createCommand } from '../utils/helpers';
 
 const availableVariables = CONFIG_VARIABLES.join(', ');
-const description = `Sets configuration <variable> to [value(s)...]. Variables available: ${availableVariables}. Configuration is persisted in \`${configFilePath}\`.
+const description = `Sets configuration <variable> to [value(s)...]. Variables available: ${availableVariables}. Configuration is persisted in \`${configFilePath()}\`.
 
 	Examples:
 	- set json true
@@ -52,7 +52,7 @@ const setNestedConfigProperty = (config, path, value) => {
 				throw new ValidationError(
 					`Config file could not be written: property '${dotNotationArray.join(
 						'.',
-					)}' was not found. It looks like your configuration file is corrupted. Please check the file at ${configFilePath} or remove it (a fresh default configuration file will be created when you run Lisky again).`,
+					)}' was not found. It looks like your configuration file is corrupted. Please check the file at ${configFilePath()} or remove it (a fresh default configuration file will be created when you run Lisky again).`,
 				);
 			}
 			// eslint-disable-next-line no-param-reassign

--- a/src/index.js
+++ b/src/index.js
@@ -19,9 +19,9 @@ import path from 'path';
 import chalk from 'chalk';
 import vorpal from 'vorpal';
 import { version } from '../package.json';
-import config from './utils/config';
+import { getConfig } from './utils/config';
 
-const name = config.name || 'lisky';
+const name = getConfig().name || 'lisky';
 const lisky = vorpal();
 
 const commandsDir = path.join(__dirname, 'commands');

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -14,7 +14,7 @@
  *
  */
 import elements from 'lisk-elements';
-import config from './config';
+import { getConfig } from './config';
 import { NETHASHES } from './constants';
 
 const { APIClient } = elements;
@@ -26,7 +26,7 @@ const seedNodes = {
 };
 
 const getAPIClient = () => {
-	const { nodes, network } = config.api;
+	const { nodes, network } = getConfig().api;
 	const nethash = NETHASHES[network] || network;
 	const clientNodes = nodes && nodes.length > 0 ? nodes : seedNodes[network];
 	return new APIClient(clientNodes, { nethash });

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -26,7 +26,7 @@ const seedNodes = {
 };
 
 const getAPIClient = () => {
-	const { nodes, network } = getConfig().api;
+	const { api: { nodes, network } } = getConfig();
 	const nethash = NETHASHES[network] || network;
 	const clientNodes = nodes && nodes.length > 0 ? nodes : seedNodes[network];
 	return new APIClient(clientNodes, { nethash });

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -87,9 +87,7 @@ const attemptToValidateConfig = (config, path) => {
 };
 
 export const setConfig = newConfig => {
-	if (!process.env.EXEC_FILE_CHILD) {
-		checkLockfile(lockfilePath);
-	}
+	checkLockfile(lockfilePath);
 	lockfile.lockSync(lockfilePath);
 	try {
 		writeJSONSync(configFilePath, newConfig);

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -26,10 +26,10 @@ const configDirName = '.lisky';
 const configFileName = 'config.json';
 const lockfileName = 'config.lock';
 const homedir = os.homedir();
-const configDirPath =
+const configDirPath = () =>
 	process.env.LISKY_CONFIG_DIR || `${homedir}/${configDirName}`;
-export const configFilePath = `${configDirPath}/${configFileName}`;
-const lockfilePath = `${configDirPath}/${lockfileName}`;
+export const configFilePath = () => `${configDirPath()}/${configFileName}`;
+const lockfilePath = () => `${configDirPath()}/${lockfileName}`;
 
 const attemptCallWithWarning = (fn, path) => {
 	try {
@@ -61,7 +61,7 @@ const attemptToCreateFile = path => {
 
 const checkLockfile = path => {
 	const locked = lockfile.checkSync(path);
-	const errorMessage = `Config lockfile at ${lockfilePath} found. Are you running Lisky in another process?`;
+	const errorMessage = `Config lockfile at ${lockfilePath()} found. Are you running Lisky in another process?`;
 	if (locked) {
 		logger.error(errorMessage);
 		process.exit(1);
@@ -87,30 +87,30 @@ const attemptToValidateConfig = (config, path) => {
 };
 
 export const setConfig = newConfig => {
-	checkLockfile(lockfilePath);
-	lockfile.lockSync(lockfilePath);
+	checkLockfile(lockfilePath());
+	lockfile.lockSync(lockfilePath());
 	try {
-		writeJSONSync(configFilePath, newConfig);
+		writeJSONSync(configFilePath(), newConfig);
 		return true;
 	} catch (e) {
 		return false;
 	} finally {
-		lockfile.unlockSync(lockfilePath);
+		lockfile.unlockSync(lockfilePath());
 	}
 };
 
 export const getConfig = () => {
-	if (!fs.existsSync(configDirPath)) {
-		attemptToCreateDir(configDirPath);
+	if (!fs.existsSync(configDirPath())) {
+		attemptToCreateDir(configDirPath());
 	}
 
-	if (!fs.existsSync(configFilePath)) {
-		attemptToCreateFile(configFilePath);
+	if (!fs.existsSync(configFilePath())) {
+		attemptToCreateFile(configFilePath());
 		return defaultConfig;
 	}
 
-	const config = attemptToReadJSONFile(configFilePath);
-	attemptToValidateConfig(config, configFilePath);
+	const config = attemptToReadJSONFile(configFilePath());
+	attemptToValidateConfig(config, configFilePath());
 
 	return config;
 };

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -62,10 +62,10 @@ const attemptToCreateFile = path => {
 const checkLockfile = path => {
 	const locked = lockfile.checkSync(path);
 	const errorMessage = `Config lockfile at ${lockfilePath} found. Are you running Lisky in another process?`;
-  if (locked) {
+	if (locked) {
 		logger.error(errorMessage);
 		process.exit(1);
-  }
+	}
 };
 
 const attemptToReadJSONFile = path => {
@@ -87,18 +87,18 @@ const attemptToValidateConfig = (config, path) => {
 };
 
 export const setConfig = newConfig => {
-  if (!process.env.EXEC_FILE_CHILD) {
+	if (!process.env.EXEC_FILE_CHILD) {
 		checkLockfile(lockfilePath);
 	}
-  lockfile.lockSync(lockfilePath);
-  try {
+	lockfile.lockSync(lockfilePath);
+	try {
 		writeJSONSync(configFilePath, newConfig);
 		return true;
 	} catch (e) {
 		return false;
-  } finally {
-    lockfile.unlockSync(lockfilePath);
-  }
+	} finally {
+		lockfile.unlockSync(lockfilePath);
+	}
 };
 
 export const getConfig = () => {
@@ -112,9 +112,7 @@ export const getConfig = () => {
 	}
 
 	const config = attemptToReadJSONFile(configFilePath);
-  attemptToValidateConfig(config, configFilePath);
+	attemptToValidateConfig(config, configFilePath);
 
 	return config;
 };
-
-export default getConfig();

--- a/src/utils/print.js
+++ b/src/utils/print.js
@@ -14,7 +14,7 @@
  *
  */
 import stripANSI from 'strip-ansi';
-import config from './config';
+import { getConfig } from './config';
 import { shouldUseJSONOutput, shouldUsePrettyOutput } from './helpers';
 import tablify from './tablify';
 
@@ -32,6 +32,7 @@ const removeANSI = result =>
 
 const print = (vorpal, options = {}) =>
 	function printResult(result) {
+    const config = getConfig();
 		const useJSONOutput = shouldUseJSONOutput(config, options);
 		const prettifyOutput = shouldUsePrettyOutput(config, options);
 		const resultToPrint = useJSONOutput ? removeANSI(result) : result;

--- a/src/utils/print.js
+++ b/src/utils/print.js
@@ -32,7 +32,7 @@ const removeANSI = result =>
 
 const print = (vorpal, options = {}) =>
 	function printResult(result) {
-    const config = getConfig();
+		const config = getConfig();
 		const useJSONOutput = shouldUseJSONOutput(config, options);
 		const prettifyOutput = shouldUsePrettyOutput(config, options);
 		const resultToPrint = useJSONOutput ? removeANSI(result) : result;

--- a/test/specs/commands/config.js
+++ b/test/specs/commands/config.js
@@ -13,11 +13,13 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import { setUpCommandConfig } from '../../steps/setup';
 import * as given from '../../steps/1_given';
 import * as when from '../../steps/2_when';
 import * as then from '../../steps/3_then';
 
 describe('config command', () => {
+	beforeEach(setUpCommandConfig);
 	Given('a config', given.aConfig, () => {
 		Given('an action "config"', given.anAction, () => {
 			When('the action is called', when.theActionIsCalled, () => {

--- a/test/specs/commands/set.js
+++ b/test/specs/commands/set.js
@@ -141,8 +141,8 @@ describe('set command', () => {
 															then.itShouldUpdateTheConfigVariableToBoolean,
 														);
 														Then(
-															'it should write the updated config to the config file',
-															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															'it should call setConfig with the updated config',
+															then.itShouldCallSetConfigWithTheUpdatedConfig,
 														);
 														Then(
 															'it should resolve to an object with message "Successfully set json to true."',
@@ -165,8 +165,8 @@ describe('set command', () => {
 															then.itShouldUpdateTheConfigVariableToBoolean,
 														);
 														Then(
-															'it should write the updated config to the config file',
-															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															'it should call setConfig with the updated config',
+															then.itShouldCallSetConfigWithTheUpdatedConfig,
 														);
 														Then(
 															'it should resolve to an object with message "Successfully set json to true."',
@@ -243,8 +243,8 @@ describe('set command', () => {
 															then.itShouldUpdateTheConfigVariableToBoolean,
 														);
 														Then(
-															'it should write the updated config to the config file',
-															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															'it should call setConfig with the updated config',
+															then.itShouldCallSetConfigWithTheUpdatedConfig,
 														);
 														Then(
 															'it should resolve to an object with message "Successfully set json to false."',
@@ -267,8 +267,8 @@ describe('set command', () => {
 															then.itShouldUpdateTheConfigVariableToBoolean,
 														);
 														Then(
-															'it should write the updated config to the config file',
-															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															'it should call setConfig with the updated config',
+															then.itShouldCallSetConfigWithTheUpdatedConfig,
 														);
 														Then(
 															'it should resolve to an object with message "Successfully set json to false."',
@@ -347,8 +347,8 @@ describe('set command', () => {
 															then.itShouldUpdateTheConfigVariableToTheFirstValue,
 														);
 														Then(
-															'it should write the updated config to the config file',
-															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															'it should call setConfig with the updated config',
+															then.itShouldCallSetConfigWithTheUpdatedConfig,
 														);
 														Then(
 															'it should resolve to an object with message "Successfully set name to my_custom_lisky."',
@@ -371,8 +371,8 @@ describe('set command', () => {
 															then.itShouldUpdateTheConfigVariableToTheFirstValue,
 														);
 														Then(
-															'it should write the updated config to the config file',
-															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															'it should call setConfig with the updated config',
+															then.itShouldCallSetConfigWithTheUpdatedConfig,
 														);
 														Then(
 															'it should resolve to an object with message "Successfully set name to my_custom_lisky."',
@@ -463,8 +463,8 @@ describe('set command', () => {
 															then.itShouldUpdateTheConfigVariableToBoolean,
 														);
 														Then(
-															'it should write the updated config to the config file',
-															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															'it should call setConfig with the updated config',
+															then.itShouldCallSetConfigWithTheUpdatedConfig,
 														);
 														Then(
 															'it should resolve to an object with message "Successfully set pretty to true."',
@@ -487,8 +487,8 @@ describe('set command', () => {
 															then.itShouldUpdateTheConfigVariableToBoolean,
 														);
 														Then(
-															'it should write the updated config to the config file',
-															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															'it should call setConfig with the updated config',
+															then.itShouldCallSetConfigWithTheUpdatedConfig,
 														);
 														Then(
 															'it should resolve to an object with message "Successfully set pretty to true."',
@@ -565,8 +565,8 @@ describe('set command', () => {
 															then.itShouldUpdateTheConfigVariableToBoolean,
 														);
 														Then(
-															'it should write the updated config to the config file',
-															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															'it should call setConfig with the updated config',
+															then.itShouldCallSetConfigWithTheUpdatedConfig,
 														);
 														Then(
 															'it should resolve to an object with message "Successfully set pretty to false."',
@@ -589,8 +589,8 @@ describe('set command', () => {
 															then.itShouldUpdateTheConfigVariableToBoolean,
 														);
 														Then(
-															'it should write the updated config to the config file',
-															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															'it should call setConfig with the updated config',
+															then.itShouldCallSetConfigWithTheUpdatedConfig,
 														);
 														Then(
 															'it should resolve to an object with message "Successfully set pretty to false."',
@@ -706,8 +706,8 @@ describe('set command', () => {
 																then.itShouldUpdateTheConfigNestedVariableToTheValues,
 															);
 															Then(
-																'it should write the updated config to the config file',
-																then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+																'it should call setConfig with the updated config',
+																then.itShouldCallSetConfigWithTheUpdatedConfig,
 															);
 															Then(
 																'it should resolve to an object with message "Successfully set api.nodes to http://localhost:4000,http://127.0.0.1."',
@@ -730,8 +730,8 @@ describe('set command', () => {
 																then.itShouldUpdateTheConfigNestedVariableToTheValues,
 															);
 															Then(
-																'it should write the updated config to the config file',
-																then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+																'it should call setConfig with the updated config',
+																then.itShouldCallSetConfigWithTheUpdatedConfig,
 															);
 															Then(
 																'it should resolve to an object with message "Successfully set api.nodes to http://localhost:4000,http://127.0.0.1."',
@@ -763,8 +763,8 @@ describe('set command', () => {
 															then.itShouldUpdateTheConfigNestedVariableToTheValues,
 														);
 														Then(
-															'it should write the updated config to the config file',
-															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															'it should call setConfig with the updated config',
+															then.itShouldCallSetConfigWithTheUpdatedConfig,
 														);
 														Then(
 															'it should resolve to an object with message "Successfully set api.nodes to http://localhost:4000."',
@@ -787,8 +787,8 @@ describe('set command', () => {
 															then.itShouldUpdateTheConfigNestedVariableToTheValues,
 														);
 														Then(
-															'it should write the updated config to the config file',
-															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															'it should call setConfig with the updated config',
+															then.itShouldCallSetConfigWithTheUpdatedConfig,
 														);
 														Then(
 															'it should resolve to an object with message "Successfully set api.nodes to http://localhost:4000."',
@@ -819,8 +819,8 @@ describe('set command', () => {
 															then.itShouldUpdateTheConfigNestedVariableToTheValues,
 														);
 														Then(
-															'it should write the updated config to the config file',
-															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															'it should call setConfig with the updated config',
+															then.itShouldCallSetConfigWithTheUpdatedConfig,
 														);
 														Then(
 															'it should resolve to an object with message "Successfully reset api.nodes."',
@@ -843,8 +843,8 @@ describe('set command', () => {
 															then.itShouldUpdateTheConfigNestedVariableToTheValues,
 														);
 														Then(
-															'it should write the updated config to the config file',
-															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															'it should call setConfig with the updated config',
+															then.itShouldCallSetConfigWithTheUpdatedConfig,
 														);
 														Then(
 															'it should resolve to an object with message "Successfully reset api.nodes."',
@@ -874,8 +874,8 @@ describe('set command', () => {
 														then.itShouldUpdateTheConfigNestedVariableToEmptyArray,
 													);
 													Then(
-														'it should write the updated config to the config file',
-														then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+														'it should call setConfig with the updated config',
+														then.itShouldCallSetConfigWithTheUpdatedConfig,
 													);
 													Then(
 														'it should resolve to an object with message "Successfully reset api.nodes."',
@@ -898,8 +898,8 @@ describe('set command', () => {
 														then.itShouldUpdateTheConfigNestedVariableToEmptyArray,
 													);
 													Then(
-														'it should write the updated config to the config file',
-														then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+														'it should call setConfig with the updated config',
+														then.itShouldCallSetConfigWithTheUpdatedConfig,
 													);
 													Then(
 														'it should resolve to an object with message "Successfully reset api.nodes."',
@@ -975,8 +975,8 @@ describe('set command', () => {
 															then.itShouldUpdateTheConfigNestedVariableToTheFirstValue,
 														);
 														Then(
-															'it should write the updated config to the config file',
-															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															'it should call setConfig with the updated config',
+															then.itShouldCallSetConfigWithTheUpdatedConfig,
 														);
 														Then(
 															'it should resolve to an object with message "Successfully set api.network to main."',
@@ -999,8 +999,8 @@ describe('set command', () => {
 															then.itShouldUpdateTheConfigNestedVariableToTheFirstValue,
 														);
 														Then(
-															'it should write the updated config to the config file',
-															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															'it should call setConfig with the updated config',
+															then.itShouldCallSetConfigWithTheUpdatedConfig,
 														);
 														Then(
 															'it should resolve to an object with message "Successfully set api.network to main."',
@@ -1031,8 +1031,8 @@ describe('set command', () => {
 															then.itShouldUpdateTheConfigNestedVariableToTheFirstValue,
 														);
 														Then(
-															'it should write the updated config to the config file',
-															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															'it should call setConfig with the updated config',
+															then.itShouldCallSetConfigWithTheUpdatedConfig,
 														);
 														Then(
 															'it should resolve to an object with message "Successfully set api.network to test."',
@@ -1055,8 +1055,8 @@ describe('set command', () => {
 															then.itShouldUpdateTheConfigNestedVariableToTheFirstValue,
 														);
 														Then(
-															'it should write the updated config to the config file',
-															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															'it should call setConfig with the updated config',
+															then.itShouldCallSetConfigWithTheUpdatedConfig,
 														);
 														Then(
 															'it should resolve to an object with message "Successfully set api.network to test."',
@@ -1087,8 +1087,8 @@ describe('set command', () => {
 															then.itShouldUpdateTheConfigNestedVariableToTheFirstValue,
 														);
 														Then(
-															'it should write the updated config to the config file',
-															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															'it should call setConfig with the updated config',
+															then.itShouldCallSetConfigWithTheUpdatedConfig,
 														);
 														Then(
 															'it should resolve to an object with message "Successfully set api.network to beta."',
@@ -1111,8 +1111,8 @@ describe('set command', () => {
 															then.itShouldUpdateTheConfigNestedVariableToTheFirstValue,
 														);
 														Then(
-															'it should write the updated config to the config file',
-															then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+															'it should call setConfig with the updated config',
+															then.itShouldCallSetConfigWithTheUpdatedConfig,
 														);
 														Then(
 															'it should resolve to an object with message "Successfully set api.network to beta."',
@@ -1192,8 +1192,8 @@ describe('set command', () => {
 																then.itShouldUpdateTheConfigNestedVariableToTheFirstValue,
 															);
 															Then(
-																'it should write the updated config to the config file',
-																then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+																'it should call setConfig with the updated config',
+																then.itShouldCallSetConfigWithTheUpdatedConfig,
 															);
 															Then(
 																'it should resolve to an object with message "Successfully set api.network to aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa."',
@@ -1216,8 +1216,8 @@ describe('set command', () => {
 																then.itShouldUpdateTheConfigNestedVariableToTheFirstValue,
 															);
 															Then(
-																'it should write the updated config to the config file',
-																then.itShouldWriteTheUpdatedConfigToTheConfigFile,
+																'it should call setConfig with the updated config',
+																then.itShouldCallSetConfigWithTheUpdatedConfig,
 															);
 															Then(
 																'it should resolve to an object with message "Successfully set api.network to aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa."',

--- a/test/specs/utils/api.js
+++ b/test/specs/utils/api.js
@@ -13,120 +13,104 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import { setUpUtilAPI } from '../../steps/setup';
 import * as given from '../../steps/1_given';
 import * as when from '../../steps/2_when';
 import * as then from '../../steps/3_then';
 
 describe('API util', () => {
+	beforeEach(setUpUtilAPI);
 	Given(
-		'a config with "api.network" set to "main"',
-		given.aConfigWithAPINetworkSetTo,
+		'a config with api.network and api.nodes set to "main" and "http://localhost:4000"',
+		given.aConfigWithAPINetworkAndNodesSetTo,
 		() => {
-			Given(
-				'a config with "api.nodes" set to "http://localhost:4000"',
-				given.aConfigWithAPINodesSetTo,
+			When(
+				'a API Client instance is created',
+				when.aLiskAPIInstanceIsCreated,
 				() => {
-					When(
-						'a API Client instance is created',
-						when.aLiskAPIInstanceIsCreated,
-						() => {
-							Then(
-								'the lisk instance should be a lisk-elements API instance',
-								then.theLiskAPIInstanceShouldBeALiskElementsAPIInstance,
-							);
-							Then(
-								'the lisk instance should have nethash equal to "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511"',
-								then.theLiskAPIInstanceShouldHaveNethashEqualTo,
-							);
-							Then(
-								'the lisk instance should have nethash equal to "http://localhost:4000"',
-								then.theLiskAPIInstanceShouldHaveCurrentNodeEqualTo,
-							);
-						},
+					Then(
+						'the lisk instance should be a lisk-elements API instance',
+						then.theLiskAPIInstanceShouldBeALiskElementsAPIInstance,
+					);
+					Then(
+						'the lisk instance should have nethash equal to "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511"',
+						then.theLiskAPIInstanceShouldHaveNethashEqualTo,
+					);
+					Then(
+						'the lisk instance should have nethash equal to "http://localhost:4000"',
+						then.theLiskAPIInstanceShouldHaveCurrentNodeEqualTo,
 					);
 				},
 			);
 		},
 	);
 	Given(
-		'a config with "api.network" set to "test"',
-		given.aConfigWithAPINetworkSetTo,
+		'a config with api.network and api.nodes set to "test" and "http://localhost:4000"',
+		given.aConfigWithAPINetworkAndNodesSetTo,
 		() => {
-			Given(
-				'a config with "api.nodes" set to "http://localhost:4000"',
-				given.aConfigWithAPINodesSetTo,
+			When(
+				'a API Client instance is created',
+				when.aLiskAPIInstanceIsCreated,
 				() => {
-					When(
-						'a API Client instance is created',
-						when.aLiskAPIInstanceIsCreated,
-						() => {
-							Then(
-								'the lisk instance should be a lisk-elements API instance',
-								then.theLiskAPIInstanceShouldBeALiskElementsAPIInstance,
-							);
-							Then(
-								'the lisk instance should have nethash equal to "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba"',
-								then.theLiskAPIInstanceShouldHaveNethashEqualTo,
-							);
-							Then(
-								'the lisk instance should have nethash equal to "http://localhost:4000"',
-								then.theLiskAPIInstanceShouldHaveCurrentNodeEqualTo,
-							);
-						},
+					Then(
+						'the lisk instance should be a lisk-elements API instance',
+						then.theLiskAPIInstanceShouldBeALiskElementsAPIInstance,
 					);
-				},
-			);
-			Given(
-				'a config with "api.nodes" set to empty array',
-				given.aConfigWithAPINodesSetTo,
-				() => {
-					When(
-						'a API Client instance is created',
-						when.aLiskAPIInstanceIsCreated,
-						() => {
-							Then(
-								'the lisk instance should be a lisk-elements API instance',
-								then.theLiskAPIInstanceShouldBeALiskElementsAPIInstance,
-							);
-							Then(
-								'the lisk instance should have nethash equal to "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba"',
-								then.theLiskAPIInstanceShouldHaveNethashEqualTo,
-							);
-							Then(
-								'the lisk instance should have nethash equal to "http://testnet.lisk.io:7000"',
-								then.theLiskAPIInstanceShouldHaveCurrentNodeEqualTo,
-							);
-						},
+					Then(
+						'the lisk instance should have nethash equal to "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba"',
+						then.theLiskAPIInstanceShouldHaveNethashEqualTo,
+					);
+					Then(
+						'the lisk instance should have nethash equal to "http://localhost:4000"',
+						then.theLiskAPIInstanceShouldHaveCurrentNodeEqualTo,
 					);
 				},
 			);
 		},
 	);
 	Given(
-		'a config with "api.network" set to "ef3844327d1fd0fc5aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2b7e859e9ca0c"',
-		given.aConfigWithAPINetworkSetTo,
+		'a config with api.network and api.nodes set to "test" and empty array',
+		given.aConfigWithAPINetworkAndNodesSetTo,
 		() => {
-			Given(
-				'a config with "api.nodes" set to "http://localhost:4000"',
-				given.aConfigWithAPINodesSetTo,
+			When(
+				'a API Client instance is created',
+				when.aLiskAPIInstanceIsCreated,
 				() => {
-					When(
-						'a API Client instance is created',
-						when.aLiskAPIInstanceIsCreated,
-						() => {
-							Then(
-								'the lisk instance should be a lisk-elements API instance',
-								then.theLiskAPIInstanceShouldBeALiskElementsAPIInstance,
-							);
-							Then(
-								'the lisk instance should have nethash equal to "ef3844327d1fd0fc5aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2b7e859e9ca0c"',
-								then.theLiskAPIInstanceShouldHaveNethashEqualTo,
-							);
-							Then(
-								'the lisk instance should have nethash equal to "http://localhost:4000"',
-								then.theLiskAPIInstanceShouldHaveCurrentNodeEqualTo,
-							);
-						},
+					Then(
+						'the lisk instance should be a lisk-elements API instance',
+						then.theLiskAPIInstanceShouldBeALiskElementsAPIInstance,
+					);
+					Then(
+						'the lisk instance should have nethash equal to "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba"',
+						then.theLiskAPIInstanceShouldHaveNethashEqualTo,
+					);
+					Then(
+						'the lisk instance should have nethash equal to "http://testnet.lisk.io:7000"',
+						then.theLiskAPIInstanceShouldHaveCurrentNodeEqualTo,
+					);
+				},
+			);
+		},
+	);
+	Given(
+		'a config with api.network and api.nodes set to "ef3844327d1fd0fc5aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2b7e859e9ca0c" and "http://localhost:4000"',
+		given.aConfigWithAPINetworkAndNodesSetTo,
+		() => {
+			When(
+				'a API Client instance is created',
+				when.aLiskAPIInstanceIsCreated,
+				() => {
+					Then(
+						'the lisk instance should be a lisk-elements API instance',
+						then.theLiskAPIInstanceShouldBeALiskElementsAPIInstance,
+					);
+					Then(
+						'the lisk instance should have nethash equal to "ef3844327d1fd0fc5aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2b7e859e9ca0c"',
+						then.theLiskAPIInstanceShouldHaveNethashEqualTo,
+					);
+					Then(
+						'the lisk instance should have nethash equal to "http://localhost:4000"',
+						then.theLiskAPIInstanceShouldHaveCurrentNodeEqualTo,
 					);
 				},
 			);

--- a/test/specs/utils/api.js
+++ b/test/specs/utils/api.js
@@ -21,8 +21,8 @@ import * as then from '../../steps/3_then';
 describe('API util', () => {
 	beforeEach(setUpUtilAPI);
 	Given(
-		'a config with api.network and api.nodes set to "main" and "http://localhost:4000"',
-		given.aConfigWithAPINetworkAndNodesSetTo,
+		'a config with api.network set to "main" and api.nodes set to "http://localhost:4000"',
+		given.aConfigWithAPINetworkAndAPINodesSetTo,
 		() => {
 			When(
 				'a API Client instance is created',
@@ -45,8 +45,8 @@ describe('API util', () => {
 		},
 	);
 	Given(
-		'a config with api.network and api.nodes set to "test" and "http://localhost:4000"',
-		given.aConfigWithAPINetworkAndNodesSetTo,
+		'a config with api.network set to "test" and api.nodes set to "http://localhost:4000"',
+		given.aConfigWithAPINetworkAndAPINodesSetTo,
 		() => {
 			When(
 				'a API Client instance is created',
@@ -69,8 +69,8 @@ describe('API util', () => {
 		},
 	);
 	Given(
-		'a config with api.network and api.nodes set to "test" and empty array',
-		given.aConfigWithAPINetworkAndNodesSetTo,
+		'a config with api.network set to "test" and api.nodes set to empty array',
+		given.aConfigWithAPINetworkAndAPINodesSetTo,
 		() => {
 			When(
 				'a API Client instance is created',
@@ -93,8 +93,8 @@ describe('API util', () => {
 		},
 	);
 	Given(
-		'a config with api.network and api.nodes set to "ef3844327d1fd0fc5aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2b7e859e9ca0c" and "http://localhost:4000"',
-		given.aConfigWithAPINetworkAndNodesSetTo,
+		'a config with api.network set to "ef3844327d1fd0fc5aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2b7e859e9ca0c" and api.nodes set to "http://localhost:4000"',
+		given.aConfigWithAPINetworkAndAPINodesSetTo,
 		() => {
 			When(
 				'a API Client instance is created',

--- a/test/specs/utils/config.js
+++ b/test/specs/utils/config.js
@@ -124,110 +124,104 @@ describe('config util', () => {
 												},
 											);
 											Given(
-												'the command is being run as a child of the exec file command',
-												given.theCommandIsBeingRunAsAChildOfTheExecFileCommand,
+												'the config file can be read',
+												given.theFileCanBeRead,
 												() => {
 													Given(
-														'the config file can be read',
-														given.theFileCanBeRead,
+														'the config file is not valid JSON',
+														given.theFileIsNotValidJSON,
+														() => {
+															When(
+																'getConfig is called',
+																when.getConfigIsCalled,
+																() => {
+																	Then(
+																		'the user should be informed that the config file cannot be read or is not valid JSON',
+																		then.theUserShouldBeInformedThatTheConfigFileCannotBeReadOrIsNotValidJSON,
+																	);
+																	Then(
+																		'the process should exit with error code "1"',
+																		then.theProcessShouldExitWithErrorCode,
+																	);
+																	Then(
+																		'the config file should not be written',
+																		then.theConfigFileShouldNotBeWritten,
+																	);
+																},
+															);
+														},
+													);
+													Given(
+														'the config file is valid',
+														given.theFileIsValid,
 														() => {
 															Given(
-																'the config file is not valid JSON',
-																given.theFileIsNotValidJSON,
+																'the config file cannot be written',
+																given.theFileCannotBeWritten,
 																() => {
 																	When(
 																		'getConfig is called',
 																		when.getConfigIsCalled,
 																		() => {
 																			Then(
-																				'the user should be informed that the config file cannot be read or is not valid JSON',
-																				then.theUserShouldBeInformedThatTheConfigFileCannotBeReadOrIsNotValidJSON,
-																			);
-																			Then(
-																				'the process should exit with error code "1"',
-																				then.theProcessShouldExitWithErrorCode,
-																			);
-																			Then(
 																				'the config file should not be written',
 																				then.theConfigFileShouldNotBeWritten,
+																			);
+																			Then(
+																				'the user’s config should be exported',
+																				then.theUsersConfigShouldBeReturned,
+																			);
+																		},
+																	);
+																	When(
+																		'setConfig is called',
+																		when.setConfigIsCalled,
+																		() => {
+																			Then(
+																				'it should lock the file',
+																				then.itShouldLockTheFile,
+																			);
+																			Then(
+																				'it should unlock the file',
+																				then.itShouldUnlockTheFile,
+																			);
+																			Then(
+																				'the default config should be written to the config file',
+																				then.theDefaultConfigShouldBeWrittenToTheConfigFile,
 																			);
 																		},
 																	);
 																},
 															);
 															Given(
-																'the config file is valid',
-																given.theFileIsValid,
+																'the config file can be written',
+																given.theFileCanBeWritten,
 																() => {
-																	Given(
-																		'the config file cannot be written',
-																		given.theFileCannotBeWritten,
+																	When(
+																		'getConfig is called',
+																		when.getConfigIsCalled,
 																		() => {
-																			When(
-																				'getConfig is called',
-																				when.getConfigIsCalled,
-																				() => {
-																					Then(
-																						'the config file should not be written',
-																						then.theConfigFileShouldNotBeWritten,
-																					);
-																					Then(
-																						'the user’s config should be exported',
-																						then.theUsersConfigShouldBeReturned,
-																					);
-																				},
+																			Then(
+																				'the config file should not be written',
+																				then.theConfigFileShouldNotBeWritten,
 																			);
-																			When(
-																				'setConfig is called',
-																				when.setConfigIsCalled,
-																				() => {
-																					Then(
-																						'it should lock the file',
-																						then.itShouldLockTheFile,
-																					);
-																					Then(
-																						'it should unlock the file',
-																						then.itShouldUnkockTheFile,
-																					);
-																					Then(
-																						'the default config should be written to the config file',
-																						then.theDefaultConfigShouldBeWrittenToTheConfigFile,
-																					);
-																				},
+																			Then(
+																				'the user’s config should be exported',
+																				then.theUsersConfigShouldBeReturned,
 																			);
 																		},
 																	);
-																	Given(
-																		'the config file can be written',
-																		given.theFileCanBeWritten,
+																	When(
+																		'setConfig is called',
+																		when.setConfigIsCalled,
 																		() => {
-																			When(
-																				'getConfig is called',
-																				when.getConfigIsCalled,
-																				() => {
-																					Then(
-																						'the config file should not be written',
-																						then.theConfigFileShouldNotBeWritten,
-																					);
-																					Then(
-																						'the user’s config should be exported',
-																						then.theUsersConfigShouldBeReturned,
-																					);
-																				},
+																			Then(
+																				'it should lock the file',
+																				then.itShouldLockTheFile,
 																			);
-																			When(
-																				'setConfig is called',
-																				when.setConfigIsCalled,
-																				() => {
-																					Then(
-																						'it should lock the file',
-																						then.itShouldLockTheFile,
-																					);
-																					Then(
-																						'it should unlock the file',
-																						then.itShouldUnkockTheFile,
-																					);
-																				},
+																			Then(
+																				'it should unlock the file',
+																				then.itShouldUnlockTheFile,
 																			);
 																		},
 																	);
@@ -275,7 +269,7 @@ describe('config util', () => {
 															);
 															Then(
 																'it should unlock the file',
-																then.itShouldUnkockTheFile,
+																then.itShouldUnlockTheFile,
 															);
 															Then(
 																'the default config should be written to the config file',

--- a/test/specs/utils/config.js
+++ b/test/specs/utils/config.js
@@ -23,18 +23,6 @@ describe('config util', () => {
 	afterEach(tearDownUtilConfig);
 	Given('a default config', given.aDefaultConfig, () => {
 		Given(
-			'the config directory path is not specified in an environmental variable',
-			given.theConfigDirectoryPathIsNotSpecifiedInAnEnvironmentalVariable,
-			() => {
-				When('the config is loaded', when.theConfigIsLoaded, () => {
-					Then(
-						'the default config should be exported',
-						then.theDefaultConfigShouldBeExported,
-					);
-				});
-			},
-		);
-		Given(
 			`a directory path "${process.env.LISKY_CONFIG_DIR}"`,
 			given.aDirectoryPath,
 			() => {
@@ -47,14 +35,10 @@ describe('config util', () => {
 								'the directory cannot be created',
 								given.theDirectoryCannotBeCreated,
 								() => {
-									When('the config is loaded', when.theConfigIsLoaded, () => {
+									When('getConfig is called', when.getConfigIsCalled, () => {
 										Then(
 											'the user should be warned that the config will not be persisted',
 											then.theUserShouldBeWarnedThatTheConfigWillNotBePersisted,
-										);
-										Then(
-											'the default config should be exported',
-											then.theDefaultConfigShouldBeExported,
 										);
 									});
 								},
@@ -63,14 +47,10 @@ describe('config util', () => {
 								'the config directory can be created',
 								given.theDirectoryCanBeCreated,
 								() => {
-									When('the config is loaded', when.theConfigIsLoaded, () => {
+									When('getConfig is called', when.getConfigIsCalled, () => {
 										Then(
 											'the default config should be written to the config file',
 											then.theDefaultConfigShouldBeWrittenToTheConfigFile,
-										);
-										Then(
-											'the default config should be exported',
-											then.theDefaultConfigShouldBeExported,
 										);
 									});
 								},
@@ -90,16 +70,12 @@ describe('config util', () => {
 										given.theFileCannotBeWritten,
 										() => {
 											When(
-												'the config is loaded',
-												when.theConfigIsLoaded,
+												'getConfig is called',
+												when.getConfigIsCalled,
 												() => {
 													Then(
 														'the user should be warned that the config will not be persisted',
 														then.theUserShouldBeWarnedThatTheConfigWillNotBePersisted,
-													);
-													Then(
-														'the default config should be exported',
-														then.theDefaultConfigShouldBeExported,
 													);
 												},
 											);
@@ -110,16 +86,12 @@ describe('config util', () => {
 										given.theFileCanBeWritten,
 										() => {
 											When(
-												'the config is loaded',
-												when.theConfigIsLoaded,
+												'getConfig is called',
+												when.getConfigIsCalled,
 												() => {
 													Then(
 														'the default config should be written to the config file',
 														then.theDefaultConfigShouldBeWrittenToTheConfigFile,
-													);
-													Then(
-														'the default config should be exported',
-														then.theDefaultConfigShouldBeExported,
 													);
 												},
 											);
@@ -136,8 +108,8 @@ describe('config util', () => {
 										given.thereIsAConfigLockfile,
 										() => {
 											When(
-												'the config is loaded',
-												when.theConfigIsLoaded,
+												'setConfig is called',
+												when.setConfigIsCalled,
 												() => {
 													Then(
 														`the user should be informed that a config lockfile was found at path "${
@@ -148,10 +120,6 @@ describe('config util', () => {
 													Then(
 														'the process should exit with error code "1"',
 														then.theProcessShouldExitWithErrorCode,
-													);
-													Then(
-														'the config file should not be written',
-														then.theConfigFileShouldNotBeWritten,
 													);
 												},
 											);
@@ -168,8 +136,8 @@ describe('config util', () => {
 																given.theFileIsNotValidJSON,
 																() => {
 																	When(
-																		'the config is loaded',
-																		when.theConfigIsLoaded,
+																		'getConfig is called',
+																		when.getConfigIsCalled,
 																		() => {
 																			Then(
 																				'the user should be informed that the config file cannot be read or is not valid JSON',
@@ -196,8 +164,8 @@ describe('config util', () => {
 																		given.theFileCannotBeWritten,
 																		() => {
 																			When(
-																				'the config is loaded',
-																				when.theConfigIsLoaded,
+																				'getConfig is called',
+																				when.getConfigIsCalled,
 																				() => {
 																					Then(
 																						'the config file should not be written',
@@ -205,7 +173,25 @@ describe('config util', () => {
 																					);
 																					Then(
 																						'the user’s config should be exported',
-																						then.theUsersConfigShouldBeExported,
+																						then.theUsersConfigShouldBeReturned,
+																					);
+																				},
+																			);
+																			When(
+																				'setConfig is called',
+																				when.setConfigIsCalled,
+																				() => {
+																					Then(
+																						'it should lock the file',
+																						then.itShouldLockTheFile,
+																					);
+																					Then(
+																						'it should unlock the file',
+																						then.itShouldUnkockTheFile,
+																					);
+																					Then(
+																						'the default config should be written to the config file',
+																						then.theDefaultConfigShouldBeWrittenToTheConfigFile,
 																					);
 																				},
 																			);
@@ -216,8 +202,8 @@ describe('config util', () => {
 																		given.theFileCanBeWritten,
 																		() => {
 																			When(
-																				'the config is loaded',
-																				when.theConfigIsLoaded,
+																				'getConfig is called',
+																				when.getConfigIsCalled,
 																				() => {
 																					Then(
 																						'the config file should not be written',
@@ -225,7 +211,21 @@ describe('config util', () => {
 																					);
 																					Then(
 																						'the user’s config should be exported',
-																						then.theUsersConfigShouldBeExported,
+																						then.theUsersConfigShouldBeReturned,
+																					);
+																				},
+																			);
+																			When(
+																				'setConfig is called',
+																				when.setConfigIsCalled,
+																				() => {
+																					Then(
+																						'it should lock the file',
+																						then.itShouldLockTheFile,
+																					);
+																					Then(
+																						'it should unlock the file',
+																						then.itShouldUnkockTheFile,
 																					);
 																				},
 																			);
@@ -248,8 +248,8 @@ describe('config util', () => {
 												given.theFileCannotBeRead,
 												() => {
 													When(
-														'the config is loaded',
-														when.theConfigIsLoaded,
+														'getConfig is called',
+														when.getConfigIsCalled,
 														() => {
 															Then(
 																'the user should be informed that the config file cannot be read or is not valid JSON',
@@ -265,6 +265,24 @@ describe('config util', () => {
 															);
 														},
 													);
+													When(
+														'setConfig is called',
+														when.setConfigIsCalled,
+														() => {
+															Then(
+																'it should lock the file',
+																then.itShouldLockTheFile,
+															);
+															Then(
+																'it should unlock the file',
+																then.itShouldUnkockTheFile,
+															);
+															Then(
+																'the default config should be written to the config file',
+																then.theDefaultConfigShouldBeWrittenToTheConfigFile,
+															);
+														},
+													);
 												},
 											);
 											Given(
@@ -276,8 +294,8 @@ describe('config util', () => {
 														given.theFileIsNotValidJSON,
 														() => {
 															When(
-																'the config is loaded',
-																when.theConfigIsLoaded,
+																'getConfig is called',
+																when.getConfigIsCalled,
 																() => {
 																	Then(
 																		'the user should be informed that the config file cannot be read or is not valid JSON',
@@ -300,8 +318,8 @@ describe('config util', () => {
 														given.theFileIsMissingRequiredKeys,
 														() => {
 															When(
-																'the config is loaded',
-																when.theConfigIsLoaded,
+																'getConfig is called',
+																when.getConfigIsCalled,
 																() => {
 																	Then(
 																		`the user should be informed that the config file at "${
@@ -326,16 +344,16 @@ describe('config util', () => {
 														given.theFileIsValid,
 														() => {
 															When(
-																'the config is loaded',
-																when.theConfigIsLoaded,
+																'getConfig is called',
+																when.getConfigIsCalled,
 																() => {
 																	Then(
 																		'the config file should not be written',
 																		then.theConfigFileShouldNotBeWritten,
 																	);
 																	Then(
-																		'the user’s config should be exported',
-																		then.theUsersConfigShouldBeExported,
+																		'the user’s config should be returned',
+																		then.theUsersConfigShouldBeReturned,
 																	);
 																},
 															);

--- a/test/specs/utils/config.js
+++ b/test/specs/utils/config.js
@@ -23,6 +23,18 @@ describe('config util', () => {
 	afterEach(tearDownUtilConfig);
 	Given('a default config', given.aDefaultConfig, () => {
 		Given(
+			'the config directory path is not specified in an environmental variable',
+			given.theConfigDirectoryPathIsNotSpecifiedInAnEnvironmentalVariable,
+			() => {
+				When('getConfig is called', when.getConfigIsCalled, () => {
+					Then(
+						'the default config should be returned',
+						then.theDefaultConfigShouldBeReturned,
+					);
+				});
+			},
+		);
+		Given(
 			`a directory path "${process.env.LISKY_CONFIG_DIR}"`,
 			given.aDirectoryPath,
 			() => {
@@ -168,7 +180,7 @@ describe('config util', () => {
 																				then.theConfigFileShouldNotBeWritten,
 																			);
 																			Then(
-																				'the user’s config should be exported',
+																				'the user’s config should be returned',
 																				then.theUsersConfigShouldBeReturned,
 																			);
 																		},
@@ -206,7 +218,7 @@ describe('config util', () => {
 																				then.theConfigFileShouldNotBeWritten,
 																			);
 																			Then(
-																				'the user’s config should be exported',
+																				'the user’s config should be returned',
 																				then.theUsersConfigShouldBeReturned,
 																			);
 																		},

--- a/test/specs/utils/helpers.js
+++ b/test/specs/utils/helpers.js
@@ -16,7 +16,8 @@
 import {
 	setUpUtilCreateCommand,
 	setUpUtilWrapActionCreator,
-	setUpUtilHelpers,
+	setUpUtilHelpersJsonOutput,
+	setUpUtilHelpersPrettyOutput,
 } from '../../steps/setup';
 import * as given from '../../steps/1_given';
 import * as when from '../../steps/2_when';
@@ -562,7 +563,7 @@ describe('utils helpers', () => {
 		);
 	});
 	describe('#shouldUseJSONOutput', () => {
-		beforeEach(setUpUtilHelpers);
+		beforeEach(setUpUtilHelpersJsonOutput);
 		When(
 			'shouldUseJSONOutput is called with the config and the options',
 			when.shouldUseJSONOutputIsCalledWithTheConfigAndOptions,
@@ -698,7 +699,7 @@ describe('utils helpers', () => {
 		});
 	});
 	describe('#shouldUsePrettyOutput', () => {
-		beforeEach(setUpUtilHelpers);
+		beforeEach(setUpUtilHelpersPrettyOutput);
 		Given(
 			'a config with pretty set to true',
 			given.aConfigWithPrettySetTo,

--- a/test/specs/utils/helpers.js
+++ b/test/specs/utils/helpers.js
@@ -16,6 +16,7 @@
 import {
 	setUpUtilCreateCommand,
 	setUpUtilWrapActionCreator,
+	setUpUtilHelpers,
 } from '../../steps/setup';
 import * as given from '../../steps/1_given';
 import * as when from '../../steps/2_when';
@@ -561,6 +562,7 @@ describe('utils helpers', () => {
 		);
 	});
 	describe('#shouldUseJSONOutput', () => {
+		beforeEach(setUpUtilHelpers);
 		When(
 			'shouldUseJSONOutput is called with the config and the options',
 			when.shouldUseJSONOutputIsCalledWithTheConfigAndOptions,
@@ -696,6 +698,7 @@ describe('utils helpers', () => {
 		});
 	});
 	describe('#shouldUsePrettyOutput', () => {
+		beforeEach(setUpUtilHelpers);
 		Given(
 			'a config with pretty set to true',
 			given.aConfigWithPrettySetTo,

--- a/test/specs/utils/helpers.js
+++ b/test/specs/utils/helpers.js
@@ -16,7 +16,7 @@
 import {
 	setUpUtilCreateCommand,
 	setUpUtilWrapActionCreator,
-	setUpUtilHelpersJsonOutput,
+	setUpUtilHelpersJSONOutput,
 	setUpUtilHelpersPrettyOutput,
 } from '../../steps/setup';
 import * as given from '../../steps/1_given';
@@ -563,7 +563,7 @@ describe('utils helpers', () => {
 		);
 	});
 	describe('#shouldUseJSONOutput', () => {
-		beforeEach(setUpUtilHelpersJsonOutput);
+		beforeEach(setUpUtilHelpersJSONOutput);
 		When(
 			'shouldUseJSONOutput is called with the config and the options',
 			when.shouldUseJSONOutputIsCalledWithTheConfigAndOptions,

--- a/test/steps/child_processes/1_given.js
+++ b/test/steps/child_processes/1_given.js
@@ -16,10 +16,6 @@
 import childProcess from 'child_process';
 import { getFirstQuotedString } from '../utils';
 
-export function theCommandIsBeingRunAsAChildOfTheExecFileCommand() {
-	process.env.EXEC_FILE_CHILD = true;
-}
-
 export function theSecondChildProcessExitsWithAnErrorThatCannotBeTrimmed() {
 	const error = new Error('myError');
 	this.test.ctx.secondChildError = error;

--- a/test/steps/config/1_given.js
+++ b/test/steps/config/1_given.js
@@ -15,7 +15,7 @@
  */
 import lockfile from 'lockfile';
 import defaultConfig from '../../../default_config.json';
-import * as currentConfig from '../../../src/utils/config';
+import * as configUtils from '../../../src/utils/config';
 import { getFirstBoolean, getBooleans, getQuotedStrings } from '../utils';
 
 export function aConfigWithUnknownProperties() {
@@ -23,7 +23,7 @@ export function aConfigWithUnknownProperties() {
 		corrupted: 'config',
 		invalid: 'names',
 	};
-	currentConfig.default = config;
+	configUtils.getConfig.returns(config);
 	this.test.ctx.config = config;
 }
 
@@ -37,7 +37,7 @@ export function aConfig() {
 		},
 		pretty: true,
 	};
-	currentConfig.default = config;
+	configUtils.getConfig.returns(config);
 	this.test.ctx.config = config;
 }
 
@@ -45,31 +45,29 @@ export function aDefaultConfig() {
 	this.test.ctx.defaultConfig = defaultConfig;
 }
 
+export function theConfigFileCannotBeWritten() {
+	configUtils.setConfig.returns(false);
+}
+
 export function aConfigWithJsonSetTo() {
 	const json = getFirstBoolean(this.test.parent.title);
 	const config = { json };
 
-	currentConfig.default = config;
+	configUtils.getConfig.returns(config);
 	this.test.ctx.config = config;
 }
 
-export function aConfigWithAPINodesSetTo() {
-	const nodes = getQuotedStrings(this.test.parent.title).slice(1);
-	const { api } = currentConfig.default;
-	api.nodes = nodes;
-	const config = { api };
+export function aConfigWithAPINetworkAndNodesSetTo() {
+	const [network, node] = getQuotedStrings(this.test.parent.title);
+	const nodes = node ? [node] : [];
+	const config = {
+		api: {
+			network,
+			nodes,
+		},
+	};
 
-	currentConfig.default = config;
-	this.test.ctx.config = config;
-}
-
-export function aConfigWithAPINetworkSetTo() {
-	const network = getQuotedStrings(this.test.parent.title)[1];
-	const { api } = currentConfig.default;
-	api.network = network;
-	const config = { api };
-
-	currentConfig.default = config;
+	configUtils.getConfig.returns(config);
 	this.test.ctx.config = config;
 }
 
@@ -77,7 +75,7 @@ export function aConfigWithPrettySetTo() {
 	const pretty = getFirstBoolean(this.test.parent.title);
 	const config = { pretty };
 
-	currentConfig.default = config;
+	configUtils.getConfig.returns(config);
 	this.test.ctx.config = config;
 }
 
@@ -85,13 +83,12 @@ export function aConfigWithJsonSetToAndPrettySetTo() {
 	const [json, pretty] = getBooleans(this.test.parent.title);
 	const config = { json, pretty };
 
-	currentConfig.default = config;
+	configUtils.getConfig.returns(config);
 	this.test.ctx.config = config;
 }
 
 export function thereIsAConfigLockfile() {
-	const error = new Error('Found a lockfile');
-	lockfile.lock.throws(error);
+	lockfile.checkSync.returns(true);
 }
 
 export function thereIsNoConfigLockfile() {}

--- a/test/steps/config/1_given.js
+++ b/test/steps/config/1_given.js
@@ -92,3 +92,7 @@ export function thereIsAConfigLockfile() {
 }
 
 export function thereIsNoConfigLockfile() {}
+
+export function theConfigDirectoryPathIsNotSpecifiedInAnEnvironmentalVariable() {
+	delete process.env.LISKY_CONFIG_DIR;
+}

--- a/test/steps/config/1_given.js
+++ b/test/steps/config/1_given.js
@@ -57,7 +57,7 @@ export function aConfigWithJsonSetTo() {
 	this.test.ctx.config = config;
 }
 
-export function aConfigWithAPINetworkAndNodesSetTo() {
+export function aConfigWithAPINetworkAndAPINodesSetTo() {
 	const [network, node] = getQuotedStrings(this.test.parent.title);
 	const nodes = node ? [node] : [];
 	const config = {
@@ -92,7 +92,3 @@ export function thereIsAConfigLockfile() {
 }
 
 export function thereIsNoConfigLockfile() {}
-
-export function theConfigDirectoryPathIsNotSpecifiedInAnEnvironmentalVariable() {
-	delete process.env.LISKY_CONFIG_DIR;
-}

--- a/test/steps/config/2_when.js
+++ b/test/steps/config/2_when.js
@@ -14,18 +14,22 @@
  *
  */
 import fs from 'fs';
+import { getConfig, setConfig } from '../../../src/utils/config';
 
-export function theConfigIsLoaded() {
+export function getConfigIsCalled() {
 	// IMPORTANT: This is a workaround because Node’s `require` implementation uses `fs.readFileSync`.
 	// If this step gets reused in other tests we’ll have to find a better solution.
 	const isSpy = fs.readFileSync.restore;
 	// istanbul ignore else
 	if (isSpy) fs.readFileSync.restore();
 
-	const configPath = '../../../src/utils/config';
-	// eslint-disable-next-line global-require, import/no-dynamic-require
-	this.test.ctx.config = require(configPath).default;
+	this.test.ctx.config = getConfig();
 
 	// istanbul ignore else
 	if (isSpy) sandbox.stub(fs, 'readFileSync');
+}
+
+export function setConfigIsCalled() {
+	const { defaultConfig } = this.test.ctx;
+	this.test.ctx.resultValue = setConfig(defaultConfig);
 }

--- a/test/steps/config/3_then.js
+++ b/test/steps/config/3_then.js
@@ -15,6 +15,12 @@
  */
 import { getFirstQuotedString, getFirstBoolean } from '../utils';
 import logger from '../../../src/utils/logger';
+import * as configUtils from '../../../src/utils/config';
+
+export function itShouldCallSetConfigWithTheUpdatedConfig() {
+	const { config } = this.test.ctx;
+	return expect(configUtils.setConfig).to.be.calledWithExactly(config);
+}
 
 export function itShouldUpdateTheConfigVariableToTheFirstValue() {
 	const { config, values } = this.test.ctx;
@@ -68,12 +74,12 @@ export function itShouldResolveToTheConfig() {
 	return expect(returnValue).to.eventually.eql(config);
 }
 
-export function theDefaultConfigShouldBeExported() {
+export function theDefaultConfigShouldBeReturned() {
 	const { config, defaultConfig } = this.test.ctx;
 	return expect(config).to.eql(defaultConfig);
 }
 
-export function theUsersConfigShouldBeExported() {
+export function theUsersConfigShouldBeReturned() {
 	const { config, userConfig } = this.test.ctx;
 	return expect(config).to.eql(userConfig);
 }

--- a/test/steps/config/3_then.js
+++ b/test/steps/config/3_then.js
@@ -74,11 +74,6 @@ export function itShouldResolveToTheConfig() {
 	return expect(returnValue).to.eventually.eql(config);
 }
 
-export function theDefaultConfigShouldBeReturned() {
-	const { config, defaultConfig } = this.test.ctx;
-	return expect(config).to.eql(defaultConfig);
-}
-
 export function theUsersConfigShouldBeReturned() {
 	const { config, userConfig } = this.test.ctx;
 	return expect(config).to.eql(userConfig);

--- a/test/steps/config/3_then.js
+++ b/test/steps/config/3_then.js
@@ -74,6 +74,11 @@ export function itShouldResolveToTheConfig() {
 	return expect(returnValue).to.eventually.eql(config);
 }
 
+export function theDefaultConfigShouldBeReturned() {
+	const { config, defaultConfig } = this.test.ctx;
+	return expect(config).to.eql(defaultConfig);
+}
+
 export function theUsersConfigShouldBeReturned() {
 	const { config, userConfig } = this.test.ctx;
 	return expect(config).to.eql(userConfig);

--- a/test/steps/files/1_given.js
+++ b/test/steps/files/1_given.js
@@ -30,10 +30,6 @@ export function aFilePath() {
 
 export function theConfigFileCanBeWritten() {}
 
-export function theConfigFileCannotBeWritten() {
-	fsUtils.writeJSONSync.throws('EACCES: permission denied');
-}
-
 export function thereIsAFileWithUtf8EncodedJSONContentsAtPath() {
 	const fileContents = '{\n\t"lisk": "js",\n\t"version": 1\n}';
 	const parsedFileContents = {

--- a/test/steps/files/3_then.js
+++ b/test/steps/files/3_then.js
@@ -14,15 +14,8 @@
  *
  */
 import fs from 'fs';
+import lockfile from 'lockfile';
 import * as fsUtils from '../../../src/utils/fs';
-
-export function itShouldWriteTheUpdatedConfigToTheConfigFile() {
-	const { filePath, config } = this.test.ctx;
-	return expect(fsUtils.writeJSONSync).to.be.calledWithExactly(
-		filePath,
-		config,
-	);
-}
 
 export function fsReadFileSyncShouldBeCalledWithThePathAndEncoding() {
 	const { filePath } = this.test.ctx;
@@ -77,4 +70,12 @@ export function theConfigFileShouldNotBeWritten() {
 export function itShouldResolveToTheFirstLineOfTheFile() {
 	const { returnValue, passphrase } = this.test.ctx;
 	return expect(returnValue).to.eventually.equal(passphrase);
+}
+
+export function itShouldLockTheFile() {
+	return expect(lockfile.lockSync).to.be.called;
+}
+
+export function itShouldUnkockTheFile() {
+	return expect(lockfile.unlockSync).to.be.called;
 }

--- a/test/steps/files/3_then.js
+++ b/test/steps/files/3_then.js
@@ -76,6 +76,6 @@ export function itShouldLockTheFile() {
 	return expect(lockfile.lockSync).to.be.called;
 }
 
-export function itShouldUnkockTheFile() {
+export function itShouldUnlockTheFile() {
 	return expect(lockfile.unlockSync).to.be.called;
 }

--- a/test/steps/general/1_given.js
+++ b/test/steps/general/1_given.js
@@ -14,11 +14,7 @@
  *
  */
 import { getFirstQuotedString, getQuotedStrings } from '../utils';
-import {
-	FileSystemError,
-	ValidationError,
-	PrintError,
-} from '../../../src/utils/error';
+import { FileSystemError, ValidationError } from '../../../src/utils/error';
 
 export function stringArguments() {
 	this.test.ctx.testArguments = getQuotedStrings(this.test.parent.title);
@@ -42,16 +38,6 @@ export function aFunctionThatThrowsAValidationError() {
 
 	this.test.ctx.errorMessage = errorMessage;
 	this.test.ctx.validationErrorFn = validationErrorFn;
-}
-
-export function aFunctionThatThrowsAPrintError() {
-	const errorMessage = getFirstQuotedString(this.test.parent.title);
-	const printErrorFn = () => {
-		throw new PrintError(errorMessage);
-	};
-
-	this.test.ctx.errorMessage = errorMessage;
-	this.test.ctx.printErrorFn = printErrorFn;
 }
 
 export function anErrorObject() {

--- a/test/steps/general/2_when.js
+++ b/test/steps/general/2_when.js
@@ -57,19 +57,3 @@ export function theValidationErrorIsThrown() {
 		return testFunction;
 	}
 }
-
-export function thePrintErrorIsThrown() {
-	const { printErrorFn } = this.test.ctx;
-	try {
-		const returnValue = printErrorFn();
-		// istanbul ignore next
-		this.test.ctx.returnValue = returnValue;
-		// istanbul ignore next
-		return returnValue;
-	} catch (error) {
-		const testFunction = printErrorFn.bind(null);
-		this.test.ctx.testFunction = testFunction;
-		this.test.ctx.testError = error;
-		return testFunction;
-	}
-}

--- a/test/steps/inputs/1_given.js
+++ b/test/steps/inputs/1_given.js
@@ -150,9 +150,6 @@ export function theTransactionIsProvidedViaStdIn() {
 	const { transaction } = this.test.ctx;
 
 	readline.createInterface.returns(createFakeInterface(transaction));
-	if (typeof inputUtils.getStdIn.resolves === 'function') {
-		inputUtils.getStdIn.resolves({ data: transaction });
-	}
 }
 
 export function thePasswordIsProvidedViaStdIn() {

--- a/test/steps/printing/3_then.js
+++ b/test/steps/printing/3_then.js
@@ -166,12 +166,6 @@ export function theReturnedTableShouldHaveHeaderRows() {
 	});
 }
 
-export function theReturnedTableShouldHaveARowWithTheObjectValues() {
-	const { returnValue, testObject } = this.test.ctx;
-	const values = Object.values(testObject);
-	return expect(returnValue[0]).to.eql(values);
-}
-
 export function theReturnedTableShouldHaveRowsWithTheObjectKeyAndStringifiedValues() {
 	const { returnValue, testArray } = this.test.ctx;
 	return testArray.forEach((values, i) => {

--- a/test/steps/setup.js
+++ b/test/steps/setup.js
@@ -355,7 +355,7 @@ export function setUpUtilCrypto() {
 	setUpLiskElementsCryptoStubs();
 }
 
-export function setUpUtilHelpersJsonOutput() {
+export function setUpUtilHelpersJSONOutput() {
 	setUpConfigStubs();
 }
 

--- a/test/steps/setup.js
+++ b/test/steps/setup.js
@@ -355,7 +355,11 @@ export function setUpUtilCrypto() {
 	setUpLiskElementsCryptoStubs();
 }
 
-export function setUpUtilHelpers() {
+export function setUpUtilHelpersJsonOutput() {
+	setUpConfigStubs();
+}
+
+export function setUpUtilHelpersPrettyOutput() {
 	setUpConfigStubs();
 }
 

--- a/test/steps/setup.js
+++ b/test/steps/setup.js
@@ -27,6 +27,7 @@ import logger from '../../src/utils/logger';
 import * as mnemonicInstance from '../../src/utils/mnemonic';
 import transactions from '../../src/utils/transactions';
 // Use require for stubbing
+const config = require('../../src/utils/config');
 const getAPIClient = require('../../src/utils/api');
 const print = require('../../src/utils/print');
 const query = require('../../src/utils/query');
@@ -68,8 +69,16 @@ const setUpJSONStubs = () => {
 	['parse', 'stringify'].forEach(methodName => sandbox.stub(JSON, methodName));
 };
 
+const setUpConfigStubs = () => {
+	sandbox.stub(config, 'getConfig');
+	sandbox.stub(config, 'setConfig').returns(true);
+};
+
 const setUpLockfileStubs = () => {
 	sandbox.stub(lockfile, 'lock');
+	sandbox.stub(lockfile, 'checkSync').returns(false);
+	sandbox.stub(lockfile, 'lockSync');
+	sandbox.stub(lockfile, 'unlockSync');
 };
 
 const setUpProcessStubs = () => {
@@ -278,7 +287,12 @@ export function setUpCommandList() {
 	setUpQueryStubs();
 }
 
+export function setUpCommandConfig() {
+	setUpConfigStubs();
+}
+
 export function setUpCommandSet() {
+	setUpConfigStubs();
 	setUpEnvVariable(NON_INTERACTIVE_MODE).call(this);
 	setUpFsStubs();
 	setUpFsUtilsStubs();
@@ -311,6 +325,10 @@ export function setUpCommandSignTransaction() {
 	setUpInputUtilsStubs();
 }
 
+export function setUpUtilAPI() {
+	setUpConfigStubs();
+}
+
 export function setUpUtilConfig() {
 	setUpEnvVariable(EXEC_FILE_CHILD).call(this);
 	setUpEnvVariable(LISKY_CONFIG_DIR).call(this);
@@ -335,6 +353,10 @@ export function setUpUtilCreateCommand() {
 
 export function setUpUtilCrypto() {
 	setUpLiskElementsCryptoStubs();
+}
+
+export function setUpUtilHelpers() {
+	setUpConfigStubs();
 }
 
 export function setUpUtilFs() {
@@ -368,6 +390,7 @@ export function setUpUtilLog() {
 }
 
 export function setUpUtilPrint() {
+	setUpConfigStubs();
 	setUpHelperStubs();
 }
 


### PR DESCRIPTION
### What was the problem?
When in non interactive mode, it was unable to pipe commands because of the lockfile.

### How did I fix it?
Only use lockfile when it needs to.
In this case, only when writing to config file, it is locked.

### How to test it?
```
./bin/lisky create transaction 0 200 123L --no-signature --json | ./bin/lisky sign transaction
```
and check if there is no error.
### Review checklist

* The PR solves #529 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
