### PR TITLE
Add timeout to readline - Closes #528

### DIFF
--- a/src/utils/input/utils.js
+++ b/src/utils/input/utils.js
@@ -31,6 +31,7 @@ const getFileDoesNotExistError = path => `File at ${path} does not exist.`;
 const getFileUnreadableError = path => `File at ${path} could not be read.`;
 const ERROR_DATA_MISSING = 'No data was provided.';
 const ERROR_DATA_SOURCE = 'Unknown data source type.';
+const DEFAULT_TIMEOUT = 100;
 
 export const splitSource = source => {
 	const delimiter = ':';
@@ -41,52 +42,64 @@ export const splitSource = source => {
 	};
 };
 
+const timeoutPromise = ms =>
+	new Promise((resolve, reject) => {
+		const id = setTimeout(() => {
+			clearTimeout(id);
+			reject(new Error(`Timed out with ${ms} ms`));
+		}, ms);
+	});
+
 export const getStdIn = ({
 	passphraseIsRequired,
 	secondPassphraseIsRequired,
 	passwordIsRequired,
 	dataIsRequired,
 } = {}) =>
-	new Promise(resolve => {
-		if (
-			!(
-				passphraseIsRequired ||
-				secondPassphraseIsRequired ||
-				passwordIsRequired ||
-				dataIsRequired
-			)
-		) {
-			return resolve({});
-		}
+	Promise.race([
+		new Promise(resolve => {
+			if (
+				!(
+					passphraseIsRequired ||
+					secondPassphraseIsRequired ||
+					passwordIsRequired ||
+					dataIsRequired
+				)
+			) {
+				return resolve({});
+			}
 
-		const lines = [];
-		const rl = readline.createInterface({ input: process.stdin });
+			const lines = [];
+			const rl = readline.createInterface({ input: process.stdin });
 
-		const handleClose = () => {
-			const passphraseIndex = 0;
-			const passphrase = passphraseIsRequired ? lines[passphraseIndex] : null;
+			const handleClose = () => {
+				const passphraseIndex = 0;
+				const passphrase = passphraseIsRequired ? lines[passphraseIndex] : null;
 
-			const secondPassphraseIndex = passphraseIndex + (passphrase !== null);
-			const secondPassphrase = secondPassphraseIsRequired
-				? lines[secondPassphraseIndex]
-				: null;
+				const secondPassphraseIndex = passphraseIndex + (passphrase !== null);
+				const secondPassphrase = secondPassphraseIsRequired
+					? lines[secondPassphraseIndex]
+					: null;
 
-			const passwordIndex = secondPassphraseIndex + (secondPassphrase !== null);
-			const password = passwordIsRequired ? lines[passwordIndex] : null;
+				const passwordIndex =
+					secondPassphraseIndex + (secondPassphrase !== null);
+				const password = passwordIsRequired ? lines[passwordIndex] : null;
 
-			const dataStartIndex = passwordIndex + (password !== null);
-			const dataLines = lines.slice(dataStartIndex);
+				const dataStartIndex = passwordIndex + (password !== null);
+				const dataLines = lines.slice(dataStartIndex);
 
-			return resolve({
-				passphrase,
-				secondPassphrase,
-				password,
-				data: dataLines.length ? dataLines.join('\n') : null,
-			});
-		};
+				return resolve({
+					passphrase,
+					secondPassphrase,
+					password,
+					data: dataLines.length ? dataLines.join('\n') : null,
+				});
+			};
 
-		return rl.on('line', line => lines.push(line)).on('close', handleClose);
-	});
+			return rl.on('line', line => lines.push(line)).on('close', handleClose);
+		}),
+		timeoutPromise(DEFAULT_TIMEOUT),
+	]);
 
 export const createPromptOptions = message => ({
 	type: 'password',


### PR DESCRIPTION
### What was the problem?
When there is stdin in interactive mode which tries to use from non-vorpal stdin, it freezes since there is no stdin from non-vorpal.

### How did I fix it?
It cannot be completely fixed since it is more of bug from vorpal.
However, added timeout for readline will not result in freezing the CLI.

### How to test it?
```
list delegates genesis1 | verify message 647aac1e2df8a5c870499d7ddc82236b1e10936977537a3844a6b05ea33f9ef6 2a3ca127efcf7b2bf62ac8c3b1f5acf6997cab62ba9fde3567d188edcbacbc5dc8177fb88d03a8691ce03348f569b121bca9e7a3c43bf5c056382f35ff843c09 --message stdin
```
Try above command and check it doesn't freeze and show timeout error.

### Review checklist

* The PR solves #528
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
