### PR TITLE
Update vorpal version - Closes #531

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"lockfile": "=1.0.3",
 		"semver": "=5.5.0",
 		"strip-ansi": "=4.0.0",
-		"vorpal": "LiskHQ/vorpal#v1.0.0-lisk"
+		"vorpal": "LiskHQ/vorpal#v1.0.1-lisk"
 	},
 	"devDependencies": {
 		"babel-cli": "=6.26.0",


### PR DESCRIPTION
### What was the problem?
Double quotation with string input will cut off at a wrong place

### How did I fix it?
Fix in vorpal

### How to test it?
```
./bin/lisky broadcast transaction '{"type": 0}'
```

### Review checklist

* The PR solves #531 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
