### PR TITLE
Add node:upgrade command - Closes #690

### DIFF
--- a/src/commands/node/install.ts
+++ b/src/commands/node/install.ts
@@ -19,7 +19,11 @@ import Listr from 'listr';
 import * as os from 'os';
 import BaseCommand from '../../base';
 import { NETWORK, RELEASE_URL, SNAPSHOT_URL } from '../../utils/constants';
-import { download, extract, validateChecksum } from '../../utils/download';
+import {
+	download,
+	downloadLiskAndValidate,
+	extract,
+} from '../../utils/download';
 import { flags as commonFlags } from '../../utils/flags';
 import {
 	createDirectory,
@@ -29,7 +33,6 @@ import {
 	liskLatestUrl,
 	liskSnapshotUrl,
 	liskTar,
-	liskTarSHA256,
 	validateNetwork,
 	validateNotARootUser,
 	validURL,
@@ -171,19 +174,10 @@ export default class InstallCommand extends BaseCommand {
 						{
 							title: 'Download Lisk Core Release',
 							task: async ctx => {
-								const {
-									version,
-									liskTarUrl,
-									liskTarSHA256Url,
-								}: Options = ctx.options;
-								const LISK_RELEASE_PATH = `${cacheDir}/${liskTar(version)}`;
-								const LISK_RELEASE_SHA256_PATH = `${cacheDir}/${liskTarSHA256(
-									version,
-								)}`;
+								const { version }: Options = ctx.options;
+								const releaseUrl = `${RELEASE_URL}/${network}/${version}`;
 
-								await download(liskTarUrl, LISK_RELEASE_PATH);
-								await download(liskTarSHA256Url, LISK_RELEASE_SHA256_PATH);
-								await validateChecksum(cacheDir, liskTarSHA256(version));
+								await downloadLiskAndValidate(cacheDir, releaseUrl, version);
 							},
 						},
 						{

--- a/src/commands/node/upgrade.ts
+++ b/src/commands/node/upgrade.ts
@@ -1,0 +1,227 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2017–2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { flags as flagParser } from '@oclif/command';
+import Axios from 'axios';
+import * as fsExtra from 'fs-extra';
+import Listr from 'listr';
+import semver from 'semver';
+import BaseCommand from '../../base';
+import { NETWORK, RELEASE_URL } from '../../utils/constants';
+import { download, extract, validateChecksum } from '../../utils/download';
+import { flags as commonFlags } from '../../utils/flags';
+import { liskTar, liskTarSHA256 } from '../../utils/node/commons';
+import { defaultBackupPath, getConfig } from '../../utils/node/config';
+import {
+	describeApplication,
+	Pm2Env,
+	registerApplication,
+	unRegisterApplication,
+} from '../../utils/node/pm2';
+import { getLatestVersion } from '../../utils/node/release';
+import { exec, ExecResult } from '../../utils/worker-process';
+import StartCommand from './start';
+import StopCommand from './stop';
+
+interface Flags {
+	readonly name: string;
+	readonly version: string;
+}
+
+interface PackageJson {
+	readonly version: string;
+}
+
+const getVersionToUpgrade = async (version: string, network: string) => {
+	if (!version) {
+		const url = `${RELEASE_URL}/${network}/latest.txt`;
+		const latestVersion = await getLatestVersion(url);
+
+		return latestVersion;
+	}
+
+	return version;
+};
+
+const validateVersion = async (
+	network: string,
+	currentVersion: string,
+	toVersion: string,
+): Promise<void> => {
+	if (!semver.valid(toVersion)) {
+		throw new Error(
+			`Upgrade version: ${toVersion} has invalid format, Please refer version from release url: ${RELEASE_URL}/${network}`,
+		);
+	}
+
+	if (semver.lte(toVersion, currentVersion)) {
+		throw new Error(
+			`Upgrade version:${toVersion} should be greater than current version: ${currentVersion}`,
+		);
+	}
+
+	const url = `${RELEASE_URL}/${network}/${toVersion}`;
+	try {
+		await Axios.get(url);
+	} catch (error) {
+		if (error.message === 'Request failed with status code 404') {
+			throw new Error(
+				`Upgrade version: ${toVersion} doesn't exists in ${RELEASE_URL}/${network}`,
+			);
+		}
+		throw new Error(error.message);
+	}
+};
+
+const downloadLisk = async (
+	cacheDir: string,
+	version: string,
+	upgradeVersionURL: string,
+) => {
+	const LISK_RELEASE_PATH = `${cacheDir}/${liskTar(version)}`;
+	const LISK_RELEASE_SHA256_PATH = `${cacheDir}/${liskTarSHA256(version)}`;
+	const liskTarUrl = `${upgradeVersionURL}/${liskTar(version)}`;
+	const liskTarSHA256Url = `${upgradeVersionURL}/${liskTarSHA256(version)}`;
+
+	await download(liskTarUrl, LISK_RELEASE_PATH);
+	await download(liskTarSHA256Url, LISK_RELEASE_SHA256_PATH);
+	await validateChecksum(cacheDir, liskTarSHA256(version));
+};
+
+const backupLisk = async (installDir: string): Promise<void> => {
+	fsExtra.emptyDirSync(defaultBackupPath);
+	const { stderr }: ExecResult = await exec(
+		`mv -f ${installDir} ${defaultBackupPath}`,
+	);
+	if (stderr) {
+		throw new Error(stderr);
+	}
+};
+
+const upgradeLisk = async (
+	installDir: string,
+	name: string,
+	network: string,
+	currentVersion: string,
+): Promise<void> => {
+	const LISK_BACKUP = `${defaultBackupPath}/${name}`;
+	const LISK_OLD_PG = `${LISK_BACKUP}/pgsql/data`;
+	const LISK_PG = `${installDir}/pgsql/data/`;
+	const MODE = 0o700;
+
+	fsExtra.mkdirSync(LISK_PG, MODE);
+
+	const { stderr }: ExecResult = await exec(
+		`cp -rf ${LISK_OLD_PG}/ ${LISK_PG}/;
+    ${installDir}/bin/node ${installDir}/scripts/update_config.js --network ${network} --output ${installDir}/config.json ${LISK_BACKUP}/config.json ${currentVersion}`,
+	);
+	if (stderr) {
+		throw new Error(stderr);
+	}
+};
+
+export default class UpgradeCommand extends BaseCommand {
+	static description = 'Upgrade locally installed Lisk Core instance to specified or latest version';
+
+	static examples = [
+		'node:upgrade --name=mainnet_1.6',
+		'node:upgrade --name=mainnet_1.6 --version=1.7.1',
+		'node:upgrade --network=testnet --name=testnet_1.6',
+		'node:upgrade --network=testnet --name=testnet_1.6 --version=1.6.1',
+	];
+
+	static flags = {
+		...BaseCommand.flags,
+		name: flagParser.string({
+			...commonFlags.name,
+			default: NETWORK.MAINNET,
+		}),
+		version: flagParser.string({
+			...commonFlags.version,
+		}),
+	};
+
+	async run(): Promise<void> {
+		const { flags } = this.parse(UpgradeCommand);
+		const { name, version } = flags as Flags;
+		const { pm2_env } = await describeApplication(name);
+		const { pm_cwd: installDir, LISK_NETWORK: network } = pm2_env as Pm2Env;
+		const { version: currentVersion } = getConfig(
+			`${installDir}/package.json`,
+		) as PackageJson;
+		const upgradeVersion: string = await getVersionToUpgrade(version, network);
+		const upgradeVersionURL = `${RELEASE_URL}/${network}/${upgradeVersion}`;
+		const cacheDir = this.config.cacheDir;
+
+		const tasks = new Listr([
+			{
+				title: 'Validate Version',
+				task: async () =>
+					validateVersion(network, currentVersion, upgradeVersion),
+			},
+			{
+				title: 'Stop and Unregister Lisk Services',
+				task: () =>
+					new Listr([
+						{
+							title: 'Stop Lisk Services',
+							task: async () =>
+								StopCommand.run(['--network', network, '--name', name]),
+						},
+						{
+							title: `Unregister Lisk Core: ${name} from PM2`,
+							task: async () => unRegisterApplication(name),
+						},
+					]),
+			},
+			{
+				title: 'Download, Backup and Install Lisk Core',
+				task: () =>
+					new Listr([
+						{
+							title: `Download Lisk Core: ${upgradeVersion} Release`,
+							task: async () =>
+								downloadLisk(cacheDir, upgradeVersion, upgradeVersionURL),
+						},
+						{
+							title: `Backup Lisk Core: ${currentVersion} installed as ${name}`,
+							task: async () => backupLisk(installDir),
+						},
+						{
+							title: `Install Lisk Core: ${upgradeVersion}`,
+							task: async () => {
+								fsExtra.ensureDirSync(installDir);
+								await extract(cacheDir, liskTar(upgradeVersion), installDir);
+							},
+						},
+					]),
+			},
+			{
+				title: `Upgrade Lisk Core from: ${currentVersion} to: ${upgradeVersion}`,
+				task: async () =>
+					upgradeLisk(installDir, name, network, currentVersion),
+			},
+			{
+				title: `Start Lisk Core: ${upgradeVersion}`,
+				task: async () => {
+					await registerApplication(installDir, network, name);
+					await StartCommand.run(['--network', network, '--name', name]);
+				},
+			},
+		]);
+
+		await tasks.run();
+	}
+}

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -15,6 +15,7 @@
  */
 import * as axios from 'axios';
 import * as fs from 'fs';
+import { liskTar, liskTarSHA256 } from './node/commons';
 import { exec, ExecResult } from './worker-process';
 
 export const download = async (
@@ -68,4 +69,19 @@ export const extract = async (
 	}
 
 	return stdout;
+};
+
+export const downloadLiskAndValidate = async (
+	destPath: string,
+	releaseUrl: string,
+	version: string,
+) => {
+	const LISK_RELEASE_PATH = `${destPath}/${liskTar(version)}`;
+	const LISK_RELEASE_SHA256_PATH = `${destPath}/${liskTarSHA256(version)}`;
+	const liskTarUrl = `${releaseUrl}/${liskTar(version)}`;
+	const liskTarSHA256Url = `${releaseUrl}/${liskTarSHA256(version)}`;
+
+	await download(liskTarUrl, LISK_RELEASE_PATH);
+	await download(liskTarSHA256Url, LISK_RELEASE_SHA256_PATH);
+	await validateChecksum(destPath, liskTarSHA256(version));
 };

--- a/src/utils/flags.ts
+++ b/src/utils/flags.ts
@@ -73,6 +73,8 @@ const releaseUrlDescription =
 	'URL of the repository to download the Lisk Core.';
 const snapshotUrlDescription = 'URL of the Lisk Core blockchain snapshot.';
 const noSnapshotDescription = 'Install Lisk Core without blockchain snapshot';
+const versionDescription =
+	'Upgrade locally installed Lisk Core instance to specified version';
 
 export type AlphabetLowercase =
 	| 'a'
@@ -156,5 +158,9 @@ export const flags: FlagMap = {
 	},
 	noSnapshot: {
 		description: noSnapshotDescription,
+	},
+	version: {
+		char: 'v',
+		description: versionDescription,
 	},
 };

--- a/src/utils/flags.ts
+++ b/src/utils/flags.ts
@@ -160,7 +160,6 @@ export const flags: FlagMap = {
 		description: noSnapshotDescription,
 	},
 	version: {
-		char: 'v',
 		description: versionDescription,
 	},
 };

--- a/src/utils/flags.ts
+++ b/src/utils/flags.ts
@@ -73,7 +73,7 @@ const releaseUrlDescription =
 	'URL of the repository to download the Lisk Core.';
 const snapshotUrlDescription = 'URL of the Lisk Core blockchain snapshot.';
 const noSnapshotDescription = 'Install Lisk Core without blockchain snapshot';
-const versionDescription =
+const liskVersionDescription =
 	'Upgrade locally installed Lisk Core instance to specified version';
 
 export type AlphabetLowercase =
@@ -159,7 +159,7 @@ export const flags: FlagMap = {
 	noSnapshot: {
 		description: noSnapshotDescription,
 	},
-	version: {
-		description: versionDescription,
+	liskVersion: {
+		description: liskVersionDescription,
 	},
 };

--- a/src/utils/node/commons.ts
+++ b/src/utils/node/commons.ts
@@ -15,7 +15,10 @@
  */
 import * as fsExtra from 'fs-extra';
 import * as os from 'os';
-import { NETWORK, OS } from '../constants';
+import { NETWORK, OS, RELEASE_URL } from '../constants';
+import { exec, ExecResult } from '../worker-process';
+import { defaultBackupPath } from './config';
+import { getLatestVersion } from './release';
 
 export const liskInstall = (installPath: string): string =>
 	installPath.replace('~', os.homedir);
@@ -82,4 +85,50 @@ export const validURL = (url: string): void => {
 	}
 
 	throw new Error(`Invalid URL: ${url}`);
+};
+
+export const getVersionToUpgrade = async (
+	network: string,
+	version?: string,
+) => {
+	if (!version) {
+		const url = `${RELEASE_URL}/${network}/latest.txt`;
+		const latestVersion = await getLatestVersion(url);
+
+		return latestVersion;
+	}
+
+	return version;
+};
+
+export const backupLisk = async (installDir: string): Promise<void> => {
+	fsExtra.emptyDirSync(defaultBackupPath);
+	const { stderr }: ExecResult = await exec(
+		`mv -f ${installDir} ${defaultBackupPath}`,
+	);
+	if (stderr) {
+		throw new Error(stderr);
+	}
+};
+
+export const upgradeLisk = async (
+	installDir: string,
+	name: string,
+	network: string,
+	currentVersion: string,
+): Promise<void> => {
+	const LISK_BACKUP = `${defaultBackupPath}/${name}`;
+	const LISK_OLD_PG = `${LISK_BACKUP}/pgsql/data`;
+	const LISK_PG = `${installDir}/pgsql/data/`;
+	const MODE = 0o700;
+
+	fsExtra.mkdirSync(LISK_PG, MODE);
+
+	const { stderr }: ExecResult = await exec(
+		`cp -rf ${LISK_OLD_PG}/ ${LISK_PG}/;
+    ${installDir}/bin/node ${installDir}/scripts/update_config.js --network ${network} --output ${installDir}/config.json ${LISK_BACKUP}/config.json ${currentVersion}`,
+	);
+	if (stderr) {
+		throw new Error(stderr);
+	}
 };

--- a/src/utils/node/config.ts
+++ b/src/utils/node/config.ts
@@ -38,6 +38,7 @@ export interface NodeConfig {
 }
 
 export const defaultInstallationPath = path.join(os.homedir(), '.lisk/network');
+export const defaultBackupPath = `${defaultInstallationPath}/backup`;
 
 export const configPath = (network: string = 'default'): string =>
 	`config/${network}/config.json`;

--- a/src/utils/node/pm2.ts
+++ b/src/utils/node/pm2.ts
@@ -20,6 +20,7 @@ export type ProcessStatus =
 	| 'one-launch-status';
 
 export interface Pm2Env {
+	readonly LISK_NETWORK: string;
 	readonly pm_cwd: string;
 	readonly pm_uptime: number;
 	readonly status: ProcessStatus;


### PR DESCRIPTION
### What was the problem?
`lisk node:upgrade` command was not available.
### How did I fix it?
Implemented `lisk node:upgrade` command.
### How to test it?
```
./bin/run node:install --network=testnet --name=test-1.5 --no-snapshot
./bin/run node:upgrade --name=test-1.5
```
### Review checklist

* The PR resolves #690 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
