### PR TITLE
Improve UX of node management commands - closes #700

### DIFF
--- a/src/commands/node/install.ts
+++ b/src/commands/node/install.ts
@@ -211,10 +211,10 @@ export default class InstallCommand extends BaseCommand {
 								const { installDir }: Options = ctx.options;
 
 								await initDB(installDir);
-								await startDatabase(installDir);
+								await startDatabase(installDir, network);
 								await createUser(installDir, network);
 								await createDatabase(installDir, network);
-								await stopDatabase(installDir);
+								await stopDatabase(installDir, network);
 							},
 						},
 						{

--- a/src/commands/node/install.ts
+++ b/src/commands/node/install.ts
@@ -66,7 +66,7 @@ interface Options {
 
 const validatePrerequisite = (installPath: string): void => {
 	if (!isSupportedOS()) {
-		throw new Error(`Lisk Core installation is not supported on ${os.type()}`);
+		throw new Error(`Lisk installation is not supported on ${os.type()}`);
 	}
 	if (fsExtra.pathExistsSync(installPath)) {
 		throw new Error(`Installation already exists in path ${installPath}`);
@@ -103,7 +103,7 @@ const installOptions = async ({
 };
 
 export default class InstallCommand extends BaseCommand {
-	static description = 'Install Lisk Core';
+	static description = 'Install Lisk';
 
 	static examples = [
 		'node:install --name=mainnet-1.6',
@@ -153,7 +153,7 @@ export default class InstallCommand extends BaseCommand {
 
 		const tasks = new Listr([
 			{
-				title: `Install Lisk Core ${network} as ${name}`,
+				title: `Install Lisk ${network} as ${name}`,
 				task: () =>
 					new Listr([
 						{
@@ -172,7 +172,7 @@ export default class InstallCommand extends BaseCommand {
 							},
 						},
 						{
-							title: 'Download Lisk Core Release',
+							title: 'Download Lisk Release',
 							task: async ctx => {
 								const { version }: Options = ctx.options;
 								const releaseUrl = `${RELEASE_URL}/${network}/${version}`;
@@ -193,7 +193,7 @@ export default class InstallCommand extends BaseCommand {
 							},
 						},
 						{
-							title: 'Extract Lisk Core',
+							title: 'Extract Lisk',
 							task: async ctx => {
 								const { installDir, version }: Options = ctx.options;
 								createDirectory(installDir);
@@ -213,7 +213,7 @@ export default class InstallCommand extends BaseCommand {
 							},
 						},
 						{
-							title: 'Register Lisk Core',
+							title: 'Register Lisk',
 							task: async ctx => {
 								const { installDir }: Options = ctx.options;
 								await registerApplication(installDir, network, name);

--- a/src/commands/node/list.ts
+++ b/src/commands/node/list.ts
@@ -30,11 +30,12 @@ export default class ListCommand extends BaseCommand {
 		this.print(
 			apps.map(app => {
 				const { name, pm2_env } = app;
-				const { status, LISK_NETWORK: network } = pm2_env as Pm2Env;
+				const { status, LISK_NETWORK: network, version } = pm2_env as Pm2Env;
 
 				return {
 					name,
 					network,
+					version,
 					status,
 				};
 			}),

--- a/src/commands/node/list.ts
+++ b/src/commands/node/list.ts
@@ -30,13 +30,12 @@ export default class ListCommand extends BaseCommand {
 		this.print(
 			apps.map(app => {
 				const { name, pm2_env } = app;
-				const { status, pm_uptime, unstable_restarts } = pm2_env as Pm2Env;
+				const { status, LISK_NETWORK: network } = pm2_env as Pm2Env;
 
 				return {
 					name,
+					network,
 					status,
-					uptime: new Date(pm_uptime).toISOString(),
-					restart_count: unstable_restarts,
 				};
 			}),
 		);

--- a/src/commands/node/list.ts
+++ b/src/commands/node/list.ts
@@ -17,7 +17,7 @@ import BaseCommand from '../../base';
 import { listApplication, Pm2Env } from '../../utils/node/pm2';
 
 export default class ListCommand extends BaseCommand {
-	static description = 'List status of installed Lisk Core instances';
+	static description = 'List status of installed Lisk instances';
 
 	static examples = ['node:list'];
 

--- a/src/commands/node/list.ts
+++ b/src/commands/node/list.ts
@@ -29,14 +29,17 @@ export default class ListCommand extends BaseCommand {
 		const apps = await listApplication();
 		this.print(
 			apps.map(app => {
-				const { name, pm2_env } = app;
-				const { status, LISK_NETWORK: network, version } = pm2_env as Pm2Env;
+				const { name, pm2_env, monit } = app;
+				const { status, LISK_NETWORK: network, version, LISK_DB_PORT: dbPort, LISK_REDIS_PORT: redisPort } = pm2_env as Pm2Env;
 
 				return {
 					name,
 					network,
 					version,
 					status,
+					dbPort,
+					redisPort,
+					...monit
 				};
 			}),
 		);

--- a/src/commands/node/logs.ts
+++ b/src/commands/node/logs.ts
@@ -13,34 +13,31 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { flags as flagParser } from '@oclif/command';
 import * as childProcess from 'child_process';
 import BaseCommand from '../../base';
-import { NETWORK } from '../../utils/constants';
-import { flags as commonFlags } from '../../utils/flags';
 import { getNetworkConfig } from '../../utils/node/config';
 import { describeApplication, Pm2Env } from '../../utils/node/pm2';
 
-interface Flags {
+interface Args {
 	readonly name: string;
 }
 
 export default class LogsCommand extends BaseCommand {
+	static args = [
+		{
+			name: 'name',
+			description: 'Lisk installation directory name.',
+			required: true,
+		},
+	];
+
 	static description = 'Show log of a Lisk Core instance';
 
-	static examples = ['node:logs --name=testnet-1.6'];
-
-	static flags = {
-		...BaseCommand.flags,
-		name: flagParser.string({
-			...commonFlags.name,
-			default: NETWORK.MAINNET,
-		}),
-	};
+	static examples = ['node:logs testnet-1.6'];
 
 	async run(): Promise<void> {
-		const { flags } = this.parse(LogsCommand);
-		const { name } = flags as Flags;
+		const { args } = this.parse(LogsCommand);
+		const { name } = args as Args;
 
 		const { pm2_env } = await describeApplication(name);
 		const { pm_cwd: installDir, LISK_NETWORK: network } = pm2_env as Pm2Env;

--- a/src/commands/node/start/cache.ts
+++ b/src/commands/node/start/cache.ts
@@ -13,46 +13,36 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { flags as flagParser } from '@oclif/command';
 import Listr from 'listr';
 import BaseCommand from '../../../base';
-import { NETWORK } from '../../../utils/constants';
-import { flags as commonFlags } from '../../../utils/flags';
 import { isCacheRunning, startCache } from '../../../utils/node/cache';
 import { isCacheEnabled } from '../../../utils/node/config';
 import { describeApplication, Pm2Env } from '../../../utils/node/pm2';
 
-export interface Flags {
+interface Args {
 	readonly name: string;
-	readonly network: NETWORK;
 }
 
 export default class CacheCommand extends BaseCommand {
-	static description = 'Start Lisk Core Cache';
-
-	static examples = [
-		'node:start:cache --name=mainnet_1.6',
-		'node:start:cache --network=testnet --name=testnet_1.6',
+	static args = [
+		{
+			name: 'name',
+			description: 'Lisk installation directory name.',
+			required: true,
+		},
 	];
 
-	static flags = {
-		...BaseCommand.flags,
-		network: flagParser.string({
-			...commonFlags.network,
-			default: NETWORK.MAINNET,
-			options: [NETWORK.MAINNET, NETWORK.TESTNET, NETWORK.BETANET],
-		}),
-		name: flagParser.string({
-			...commonFlags.name,
-			default: NETWORK.MAINNET,
-		}),
-	};
+	static description = 'Start Lisk Cache';
+
+	static examples = [
+		'node:start:cache mainnet_1.6',
+	];
 
 	async run(): Promise<void> {
-		const { flags } = this.parse(CacheCommand);
-		const { network, name } = flags as Flags;
+		const { args } = this.parse(CacheCommand);
+		const { name } = args as Args;
 		const { pm2_env } = await describeApplication(name);
-		const { pm_cwd: installDir } = pm2_env as Pm2Env;
+		const { pm_cwd: installDir, LISK_NETWORK: network } = pm2_env as Pm2Env;
 
 		const tasks = new Listr([
 			{

--- a/src/commands/node/start/cache.ts
+++ b/src/commands/node/start/cache.ts
@@ -34,9 +34,7 @@ export default class CacheCommand extends BaseCommand {
 
 	static description = 'Start Lisk Cache';
 
-	static examples = [
-		'node:start:cache mainnet_1.6',
-	];
+	static examples = ['node:start:cache mainnet_1.6'];
 
 	async run(): Promise<void> {
 		const { args } = this.parse(CacheCommand);

--- a/src/commands/node/start/cache.ts
+++ b/src/commands/node/start/cache.ts
@@ -56,7 +56,7 @@ export default class CacheCommand extends BaseCommand {
 
 		const tasks = new Listr([
 			{
-				title: 'Start Lisk Core Cache',
+				title: 'Start Lisk Cache',
 				skip: () => !isCacheEnabled(installDir, network),
 				task: async () => {
 					const isRunning = await isCacheRunning(installDir, network);

--- a/src/commands/node/start/cache.ts
+++ b/src/commands/node/start/cache.ts
@@ -49,7 +49,7 @@ export default class CacheCommand extends BaseCommand {
 				task: async () => {
 					const isRunning = await isCacheRunning(installDir, network);
 					if (!isRunning) {
-						await startCache(installDir);
+						await startCache(installDir, network);
 					}
 				},
 			},

--- a/src/commands/node/start/database.ts
+++ b/src/commands/node/start/database.ts
@@ -61,7 +61,7 @@ export default class DatabaseCommand extends BaseCommand {
 
 		const tasks = new Listr([
 			{
-				title: 'Start Lisk Core Database',
+				title: 'Start Lisk Database',
 				task: async () => startDatabase(installDir),
 			},
 		]);

--- a/src/commands/node/start/database.ts
+++ b/src/commands/node/start/database.ts
@@ -13,49 +13,33 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { flags as flagParser } from '@oclif/command';
 import Listr from 'listr';
 import BaseCommand from '../../../base';
-import { NETWORK } from '../../../utils/constants';
-import { flags as commonFlags } from '../../../utils/flags';
 import { startDatabase } from '../../../utils/node/database';
 import { describeApplication, Pm2Env } from '../../../utils/node/pm2';
 
-export interface Flags {
+interface Args {
 	readonly name: string;
-	readonly network: NETWORK;
-	readonly 'no-snapshot': boolean;
 }
 
 export default class DatabaseCommand extends BaseCommand {
-	static description = 'Start Lisk Core Database';
-
-	static examples = [
-		'node:start:database --name=mainnet_1.6',
-		'node:start:database --network=testnet --name=testnet_1.6',
+	static args = [
+		{
+			name: 'name',
+			description: 'Lisk installation directory name.',
+			required: true,
+		},
 	];
 
-	static flags = {
-		...BaseCommand.flags,
-		network: flagParser.string({
-			...commonFlags.network,
-			default: NETWORK.MAINNET,
-			options: [NETWORK.MAINNET, NETWORK.TESTNET, NETWORK.BETANET],
-		}),
-		name: flagParser.string({
-			...commonFlags.name,
-			default: NETWORK.MAINNET,
-		}),
-		'no-snapshot': flagParser.boolean({
-			...commonFlags.noSnapshot,
-			default: false,
-			allowNo: false,
-		}),
-	};
+	static description = 'Start Lisk Database';
+
+	static examples = [
+		'node:start:database mainnet_1.6',
+	];
 
 	async run(): Promise<void> {
-		const { flags } = this.parse(DatabaseCommand);
-		const { name } = flags as Flags;
+		const { args } = this.parse(DatabaseCommand);
+		const { name } = args as Args;
 		const { pm2_env } = await describeApplication(name);
 		const { pm_cwd: installDir } = pm2_env as Pm2Env;
 

--- a/src/commands/node/start/database.ts
+++ b/src/commands/node/start/database.ts
@@ -33,9 +33,7 @@ export default class DatabaseCommand extends BaseCommand {
 
 	static description = 'Start Lisk Database';
 
-	static examples = [
-		'node:start:database mainnet_1.6',
-	];
+	static examples = ['node:start:database mainnet_1.6'];
 
 	async run(): Promise<void> {
 		const { args } = this.parse(DatabaseCommand);

--- a/src/commands/node/start/database.ts
+++ b/src/commands/node/start/database.ts
@@ -39,12 +39,12 @@ export default class DatabaseCommand extends BaseCommand {
 		const { args } = this.parse(DatabaseCommand);
 		const { name } = args as Args;
 		const { pm2_env } = await describeApplication(name);
-		const { pm_cwd: installDir } = pm2_env as Pm2Env;
+		const { pm_cwd: installDir, LISK_NETWORK: network } = pm2_env as Pm2Env;
 
 		const tasks = new Listr([
 			{
 				title: 'Start Lisk Database',
-				task: async () => startDatabase(installDir),
+				task: async () => startDatabase(installDir, network),
 			},
 		]);
 

--- a/src/commands/node/start/index.ts
+++ b/src/commands/node/start/index.ts
@@ -49,7 +49,7 @@ export default class StartCommand extends BaseCommand {
 
 		const tasks = new Listr([
 			{
-				title: 'Start Lisk Core',
+				title: 'Start Lisk Instance',
 				task: () =>
 					new Listr([
 						{
@@ -63,7 +63,7 @@ export default class StartCommand extends BaseCommand {
 								DatabaseCommand.run(['--network', network, '--name', name]),
 						},
 						{
-							title: 'Lisk Core',
+							title: 'Lisk',
 							task: async () => {
 								await restartApplication(name);
 							},

--- a/src/commands/node/start/index.ts
+++ b/src/commands/node/start/index.ts
@@ -34,12 +34,10 @@ export default class StartCommand extends BaseCommand {
 
 	static description = 'Start Lisk';
 
-	static examples = [
-		'node:start mainnet_1.6',
-	];
+	static examples = ['node:start mainnet_1.6'];
 
 	async run(): Promise<void> {
-		const { args} = this.parse(StartCommand);
+		const { args } = this.parse(StartCommand);
 		const { name } = args as Args;
 
 		const tasks = new Listr([
@@ -49,13 +47,11 @@ export default class StartCommand extends BaseCommand {
 					new Listr([
 						{
 							title: 'Cache',
-							task: async () =>
-								CacheCommand.run([name]),
+							task: async () => CacheCommand.run([name]),
 						},
 						{
 							title: 'Database',
-							task: async () =>
-								DatabaseCommand.run([name]),
+							task: async () => DatabaseCommand.run([name]),
 						},
 						{
 							title: 'Lisk',

--- a/src/commands/node/start/index.ts
+++ b/src/commands/node/start/index.ts
@@ -13,39 +13,34 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { flags as flagParser } from '@oclif/command';
 import Listr from 'listr';
 import BaseCommand from '../../../base';
-import { NETWORK } from '../../../utils/constants';
-import { flags as commonFlags } from '../../../utils/flags';
 import { restartApplication } from '../../../utils/node/pm2';
-import CacheCommand, { Flags } from './cache';
+import CacheCommand from './cache';
 import DatabaseCommand from './database';
 
-export default class StartCommand extends BaseCommand {
-	static description = 'Start Lisk Core';
+interface Args {
+	readonly name: string;
+}
 
-	static examples = [
-		'node:start --name=mainnet_1.6',
-		'node:start --network=testnet --name=testnet_1.6',
+export default class StartCommand extends BaseCommand {
+	static args = [
+		{
+			name: 'name',
+			description: 'Lisk installation directory name.',
+			required: true,
+		},
 	];
 
-	static flags = {
-		...BaseCommand.flags,
-		network: flagParser.string({
-			...commonFlags.network,
-			default: NETWORK.MAINNET,
-			options: [NETWORK.MAINNET, NETWORK.TESTNET, NETWORK.BETANET],
-		}),
-		name: flagParser.string({
-			...commonFlags.name,
-			default: NETWORK.MAINNET,
-		}),
-	};
+	static description = 'Start Lisk';
+
+	static examples = [
+		'node:start mainnet_1.6',
+	];
 
 	async run(): Promise<void> {
-		const { flags } = this.parse(StartCommand);
-		const { network, name } = flags as Flags;
+		const { args} = this.parse(StartCommand);
+		const { name } = args as Args;
 
 		const tasks = new Listr([
 			{
@@ -55,12 +50,12 @@ export default class StartCommand extends BaseCommand {
 						{
 							title: 'Cache',
 							task: async () =>
-								CacheCommand.run(['--network', network, '--name', name]),
+								CacheCommand.run([name]),
 						},
 						{
 							title: 'Database',
 							task: async () =>
-								DatabaseCommand.run(['--network', network, '--name', name]),
+								DatabaseCommand.run([name]),
 						},
 						{
 							title: 'Lisk',

--- a/src/commands/node/start/index.ts
+++ b/src/commands/node/start/index.ts
@@ -40,26 +40,15 @@ export default class StartCommand extends BaseCommand {
 		const { args } = this.parse(StartCommand);
 		const { name } = args as Args;
 
+		await CacheCommand.run([name]);
+		await DatabaseCommand.run([name]);
+
 		const tasks = new Listr([
 			{
 				title: 'Start Lisk Instance',
-				task: () =>
-					new Listr([
-						{
-							title: 'Cache',
-							task: async () => CacheCommand.run([name]),
-						},
-						{
-							title: 'Database',
-							task: async () => DatabaseCommand.run([name]),
-						},
-						{
-							title: 'Lisk',
-							task: async () => {
-								await restartApplication(name);
-							},
-						},
-					]),
+				task: async () => {
+					await restartApplication(name);
+				},
 			},
 		]);
 		await tasks.run();

--- a/src/commands/node/status.ts
+++ b/src/commands/node/status.ts
@@ -13,32 +13,29 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { flags as flagParser } from '@oclif/command';
 import BaseCommand from '../../base';
-import { NETWORK } from '../../utils/constants';
-import { flags as commonFlags } from '../../utils/flags';
 import { describeApplication, Pm2Env } from '../../utils/node/pm2';
 
-interface Flags {
+interface Args {
 	readonly name: string;
 }
 
 export default class StatusCommand extends BaseCommand {
+	static args = [
+		{
+			name: 'name',
+			description: 'Lisk installation directory name.',
+			required: true,
+		},
+	];
+
 	static description = 'Show status of a Lisk instance';
 
-	static examples = ['node:status --name=testnet-1.6'];
-
-	static flags = {
-		...BaseCommand.flags,
-		name: flagParser.string({
-			...commonFlags.name,
-			default: NETWORK.MAINNET,
-		}),
-	};
+	static examples = ['node:status testnet-1.6'];
 
 	async run(): Promise<void> {
-		const { flags } = this.parse(StatusCommand);
-		const { name } = flags as Flags;
+		const { args } = this.parse(StatusCommand);
+		const { name } = args as Args;
 
 		const { pm2_env, monit } = await describeApplication(name);
 		const {
@@ -57,7 +54,7 @@ export default class StatusCommand extends BaseCommand {
 			installationPath,
 			uptime: new Date(pm_uptime).toISOString(),
 			restart_count: unstable_restarts,
-			...monit
+			...monit,
 		});
 	}
 }

--- a/src/commands/node/status.ts
+++ b/src/commands/node/status.ts
@@ -45,12 +45,16 @@ export default class StatusCommand extends BaseCommand {
 			pm_cwd: installationPath,
 			LISK_NETWORK: network,
 			version,
+			LISK_DB_PORT: dbPort,
+			LISK_REDIS_PORT: redisPort
 		} = pm2_env as Pm2Env;
 
 		this.print({
 			status,
 			network,
 			version,
+			dbPort,
+			redisPort,
 			installationPath,
 			uptime: new Date(pm_uptime).toISOString(),
 			restart_count: unstable_restarts,

--- a/src/commands/node/status.ts
+++ b/src/commands/node/status.ts
@@ -40,13 +40,24 @@ export default class StatusCommand extends BaseCommand {
 		const { flags } = this.parse(StatusCommand);
 		const { name } = flags as Flags;
 
-		const appInfo = await describeApplication(name);
-		const { status, pm_uptime, unstable_restarts } = appInfo.pm2_env as Pm2Env;
+		const { pm2_env, monit } = await describeApplication(name);
+		const {
+			status,
+			pm_uptime,
+			unstable_restarts,
+			pm_cwd: installationPath,
+			LISK_NETWORK: network,
+			version,
+		} = pm2_env as Pm2Env;
 
 		this.print({
 			status,
+			network,
+			version,
+			installationPath,
 			uptime: new Date(pm_uptime).toISOString(),
 			restart_count: unstable_restarts,
+			...monit
 		});
 	}
 }

--- a/src/commands/node/status.ts
+++ b/src/commands/node/status.ts
@@ -24,7 +24,7 @@ interface Flags {
 }
 
 export default class StatusCommand extends BaseCommand {
-	static description = 'Show status of a Lisk Core instance';
+	static description = 'Show status of a Lisk instance';
 
 	static examples = ['node:status --name=testnet-1.6'];
 

--- a/src/commands/node/stop/cache.ts
+++ b/src/commands/node/stop/cache.ts
@@ -13,46 +13,36 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { flags as flagParser } from '@oclif/command';
 import Listr from 'listr';
 import BaseCommand from '../../../base';
-import { NETWORK } from '../../../utils/constants';
-import { flags as commonFlags } from '../../../utils/flags';
 import { isCacheRunning, stopCache } from '../../../utils/node/cache';
 import { isCacheEnabled } from '../../../utils/node/config';
 import { describeApplication, Pm2Env } from '../../../utils/node/pm2';
 
-export interface Flags {
+interface Args {
 	readonly name: string;
-	readonly network: NETWORK;
 }
 
 export default class CacheCommand extends BaseCommand {
-	static description = 'Stop Lisk Core Cache';
-
-	static examples = [
-		'node:stop:cache --name=mainnet_1.6',
-		'node:stop:cache --network=testnet --name=testnet_1.6',
+	static args = [
+		{
+			name: 'name',
+			description: 'Lisk installation directory name.',
+			required: true,
+		},
 	];
 
-	static flags = {
-		...BaseCommand.flags,
-		network: flagParser.string({
-			...commonFlags.network,
-			default: NETWORK.MAINNET,
-			options: [NETWORK.MAINNET, NETWORK.TESTNET, NETWORK.BETANET],
-		}),
-		name: flagParser.string({
-			...commonFlags.name,
-			default: NETWORK.MAINNET,
-		}),
-	};
+	static description = 'Stop Lisk Cache';
+
+	static examples = [
+		'node:stop:cache mainnet_1.6'
+	];
 
 	async run(): Promise<void> {
-		const { flags } = this.parse(CacheCommand);
-		const { network, name } = flags as Flags;
+		const { args } = this.parse(CacheCommand);
+		const { name } = args as Args;
 		const { pm2_env } = await describeApplication(name);
-		const { pm_cwd: installDir } = pm2_env as Pm2Env;
+		const { pm_cwd: installDir, LISK_NETWORK: network } = pm2_env as Pm2Env;
 
 		const tasks = new Listr([
 			{

--- a/src/commands/node/stop/cache.ts
+++ b/src/commands/node/stop/cache.ts
@@ -34,9 +34,7 @@ export default class CacheCommand extends BaseCommand {
 
 	static description = 'Stop Lisk Cache';
 
-	static examples = [
-		'node:stop:cache mainnet_1.6'
-	];
+	static examples = ['node:stop:cache mainnet_1.6'];
 
 	async run(): Promise<void> {
 		const { args } = this.parse(CacheCommand);

--- a/src/commands/node/stop/cache.ts
+++ b/src/commands/node/stop/cache.ts
@@ -56,7 +56,7 @@ export default class CacheCommand extends BaseCommand {
 
 		const tasks = new Listr([
 			{
-				title: 'Stop Lisk Core Cache',
+				title: 'Stop Lisk Cache',
 				skip: () => !isCacheEnabled(installDir, network),
 				task: async () => {
 					const isRunning = await isCacheRunning(installDir, network);

--- a/src/commands/node/stop/database.ts
+++ b/src/commands/node/stop/database.ts
@@ -33,15 +33,13 @@ export default class DatabaseCommand extends BaseCommand {
 
 	static description = 'Stop Lisk Database';
 
-	static examples = [
-		'node:stop:database mainnet_1.6',
-	];
+	static examples = ['node:stop:database mainnet_1.6'];
 
 	async run(): Promise<void> {
 		const { args } = this.parse(DatabaseCommand);
 		const { name } = args as Args;
 		const { pm2_env } = await describeApplication(name);
-		const { pm_cwd: installDir, } = pm2_env as Pm2Env;
+		const { pm_cwd: installDir } = pm2_env as Pm2Env;
 
 		const tasks = new Listr([
 			{

--- a/src/commands/node/stop/database.ts
+++ b/src/commands/node/stop/database.ts
@@ -13,51 +13,35 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { flags as flagParser } from '@oclif/command';
 import Listr from 'listr';
 import BaseCommand from '../../../base';
-import { NETWORK } from '../../../utils/constants';
-import { flags as commonFlags } from '../../../utils/flags';
 import { stopDatabase } from '../../../utils/node/database';
 import { describeApplication, Pm2Env } from '../../../utils/node/pm2';
 
-export interface Flags {
+interface Args {
 	readonly name: string;
-	readonly network: NETWORK;
-	readonly 'no-snapshot': boolean;
 }
 
 export default class DatabaseCommand extends BaseCommand {
-	static description = 'Stop Lisk Core Database';
-
-	static examples = [
-		'node:stop:database --name=mainnet_1.6',
-		'node:stop:database --network=testnet --name=testnet_1.6',
+	static args = [
+		{
+			name: 'name',
+			description: 'Lisk installation directory name.',
+			required: true,
+		},
 	];
 
-	static flags = {
-		...BaseCommand.flags,
-		network: flagParser.string({
-			...commonFlags.network,
-			default: NETWORK.MAINNET,
-			options: [NETWORK.MAINNET, NETWORK.TESTNET, NETWORK.BETANET],
-		}),
-		name: flagParser.string({
-			...commonFlags.name,
-			default: NETWORK.MAINNET,
-		}),
-		'no-snapshot': flagParser.boolean({
-			...commonFlags.noSnapshot,
-			default: false,
-			allowNo: false,
-		}),
-	};
+	static description = 'Stop Lisk Database';
+
+	static examples = [
+		'node:stop:database mainnet_1.6',
+	];
 
 	async run(): Promise<void> {
-		const { flags } = this.parse(DatabaseCommand);
-		const { name } = flags as Flags;
+		const { args } = this.parse(DatabaseCommand);
+		const { name } = args as Args;
 		const { pm2_env } = await describeApplication(name);
-		const { pm_cwd: installDir } = pm2_env as Pm2Env;
+		const { pm_cwd: installDir, } = pm2_env as Pm2Env;
 
 		const tasks = new Listr([
 			{

--- a/src/commands/node/stop/database.ts
+++ b/src/commands/node/stop/database.ts
@@ -39,12 +39,12 @@ export default class DatabaseCommand extends BaseCommand {
 		const { args } = this.parse(DatabaseCommand);
 		const { name } = args as Args;
 		const { pm2_env } = await describeApplication(name);
-		const { pm_cwd: installDir } = pm2_env as Pm2Env;
+		const { pm_cwd: installDir, LISK_NETWORK: network } = pm2_env as Pm2Env;
 
 		const tasks = new Listr([
 			{
 				title: 'Stop Lisk Database',
-				task: async () => stopDatabase(installDir),
+				task: async () => stopDatabase(installDir, network),
 			},
 		]);
 

--- a/src/commands/node/stop/database.ts
+++ b/src/commands/node/stop/database.ts
@@ -61,7 +61,7 @@ export default class DatabaseCommand extends BaseCommand {
 
 		const tasks = new Listr([
 			{
-				title: 'Stop Lisk Core Database',
+				title: 'Stop Lisk Database',
 				task: async () => stopDatabase(installDir),
 			},
 		]);

--- a/src/commands/node/stop/index.ts
+++ b/src/commands/node/stop/index.ts
@@ -49,7 +49,7 @@ export default class StopCommand extends BaseCommand {
 
 		const tasks = new Listr([
 			{
-				title: 'Stop Lisk Core',
+				title: 'Stop Lisk Instance',
 				task: () =>
 					new Listr([
 						{
@@ -63,7 +63,7 @@ export default class StopCommand extends BaseCommand {
 								DatabaseCommand.run(['--network', network, '--name', name]),
 						},
 						{
-							title: 'Lisk Core',
+							title: 'Lisk',
 							task: async () => {
 								await stopApplication(name);
 							},

--- a/src/commands/node/stop/index.ts
+++ b/src/commands/node/stop/index.ts
@@ -34,9 +34,7 @@ export default class StopCommand extends BaseCommand {
 
 	static description = 'Stop Lisk';
 
-	static examples = [
-		'node:stop mainnet_1.6',
-	];
+	static examples = ['node:stop mainnet_1.6'];
 
 	async run(): Promise<void> {
 		const { args } = this.parse(StopCommand);
@@ -49,13 +47,11 @@ export default class StopCommand extends BaseCommand {
 					new Listr([
 						{
 							title: 'Cache',
-							task: async () =>
-								CacheCommand.run([name]),
+							task: async () => CacheCommand.run([name]),
 						},
 						{
 							title: 'Database',
-							task: async () =>
-								DatabaseCommand.run([name]),
+							task: async () => DatabaseCommand.run([name]),
 						},
 						{
 							title: 'Lisk',

--- a/src/commands/node/stop/index.ts
+++ b/src/commands/node/stop/index.ts
@@ -13,39 +13,34 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { flags as flagParser } from '@oclif/command';
 import Listr from 'listr';
 import BaseCommand from '../../../base';
-import { NETWORK } from '../../../utils/constants';
-import { flags as commonFlags } from '../../../utils/flags';
 import { stopApplication } from '../../../utils/node/pm2';
-import CacheCommand, { Flags } from './cache';
+import CacheCommand from './cache';
 import DatabaseCommand from './database';
 
-export default class StopCommand extends BaseCommand {
-	static description = 'Stop Lisk Core';
+interface Args {
+	readonly name: string;
+}
 
-	static examples = [
-		'node:stop --name=mainnet_1.6',
-		'node:stop --network=testnet --name=testnet_1.6',
+export default class StopCommand extends BaseCommand {
+	static args = [
+		{
+			name: 'name',
+			description: 'Lisk installation directory name.',
+			required: true,
+		},
 	];
 
-	static flags = {
-		...BaseCommand.flags,
-		network: flagParser.string({
-			...commonFlags.network,
-			default: NETWORK.MAINNET,
-			options: [NETWORK.MAINNET, NETWORK.TESTNET, NETWORK.BETANET],
-		}),
-		name: flagParser.string({
-			...commonFlags.name,
-			default: NETWORK.MAINNET,
-		}),
-	};
+	static description = 'Stop Lisk';
+
+	static examples = [
+		'node:stop mainnet_1.6',
+	];
 
 	async run(): Promise<void> {
-		const { flags } = this.parse(StopCommand);
-		const { network, name } = flags as Flags;
+		const { args } = this.parse(StopCommand);
+		const { name } = args as Args;
 
 		const tasks = new Listr([
 			{
@@ -55,12 +50,12 @@ export default class StopCommand extends BaseCommand {
 						{
 							title: 'Cache',
 							task: async () =>
-								CacheCommand.run(['--network', network, '--name', name]),
+								CacheCommand.run([name]),
 						},
 						{
 							title: 'Database',
 							task: async () =>
-								DatabaseCommand.run(['--network', network, '--name', name]),
+								DatabaseCommand.run([name]),
 						},
 						{
 							title: 'Lisk',

--- a/src/commands/node/stop/index.ts
+++ b/src/commands/node/stop/index.ts
@@ -40,26 +40,15 @@ export default class StopCommand extends BaseCommand {
 		const { args } = this.parse(StopCommand);
 		const { name } = args as Args;
 
+		await CacheCommand.run([name]);
+		await DatabaseCommand.run([name]);
+
 		const tasks = new Listr([
 			{
 				title: 'Stop Lisk Instance',
-				task: () =>
-					new Listr([
-						{
-							title: 'Cache',
-							task: async () => CacheCommand.run([name]),
-						},
-						{
-							title: 'Database',
-							task: async () => DatabaseCommand.run([name]),
-						},
-						{
-							title: 'Lisk',
-							task: async () => {
-								await stopApplication(name);
-							},
-						},
-					]),
+				task: async () => {
+					await stopApplication(name);
+				},
 			},
 		]);
 

--- a/src/commands/node/uninstall.ts
+++ b/src/commands/node/uninstall.ts
@@ -13,12 +13,9 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { flags as flagParser } from '@oclif/command';
 import * as fsExtra from 'fs-extra';
 import Listr from 'listr';
 import BaseCommand from '../../base';
-import { NETWORK } from '../../utils/constants';
-import { flags as commonFlags } from '../../utils/flags';
 import {
 	describeApplication,
 	Pm2Env,
@@ -26,37 +23,30 @@ import {
 } from '../../utils/node/pm2';
 import StopCommand from './stop';
 
-interface Flags {
+interface Args {
 	readonly name: string;
-	readonly network: NETWORK;
 }
 
 export default class UnInstallCommand extends BaseCommand {
+	static args = [
+		{
+			name: 'name',
+			description: 'Lisk installation directory name.',
+			required: true,
+		},
+	];
+
 	static description = 'UnInstall Lisk';
 
 	static examples = [
-		'node:uninstall --name=mainnet_1.6',
-		'node:uninstall --network=testnet --name=testnet_1.6',
+		'node:uninstall mainnet_1.6',
 	];
 
-	static flags = {
-		...BaseCommand.flags,
-		network: flagParser.string({
-			...commonFlags.network,
-			default: NETWORK.MAINNET,
-			options: [NETWORK.MAINNET, NETWORK.TESTNET, NETWORK.BETANET],
-		}),
-		name: flagParser.string({
-			...commonFlags.name,
-			default: NETWORK.MAINNET,
-		}),
-	};
-
 	async run(): Promise<void> {
-		const { flags } = this.parse(UnInstallCommand);
-		const { network, name } = flags as Flags;
+		const { args } = this.parse(UnInstallCommand);
+		const { name } = args as Args;
 		const { pm2_env } = await describeApplication(name);
-		const { pm_cwd: installDir } = pm2_env as Pm2Env;
+		const { pm_cwd: installDir, LISK_NETWORK: network } = pm2_env as Pm2Env;
 
 		const tasks = new Listr([
 			{

--- a/src/commands/node/uninstall.ts
+++ b/src/commands/node/uninstall.ts
@@ -38,9 +38,7 @@ export default class UnInstallCommand extends BaseCommand {
 
 	static description = 'UnInstall Lisk';
 
-	static examples = [
-		'node:uninstall mainnet_1.6',
-	];
+	static examples = ['node:uninstall mainnet_1.6'];
 
 	async run(): Promise<void> {
 		const { args } = this.parse(UnInstallCommand);
@@ -55,8 +53,7 @@ export default class UnInstallCommand extends BaseCommand {
 					new Listr([
 						{
 							title: 'Stop Services',
-							task: async () =>
-								StopCommand.run(['--network', network, '--name', name]),
+							task: async () => StopCommand.run([name]),
 						},
 						{
 							title: 'Remove Process and Directory',

--- a/src/commands/node/uninstall.ts
+++ b/src/commands/node/uninstall.ts
@@ -32,7 +32,7 @@ interface Flags {
 }
 
 export default class UnInstallCommand extends BaseCommand {
-	static description = 'UnInstall Lisk Core';
+	static description = 'UnInstall Lisk';
 
 	static examples = [
 		'node:uninstall --name=mainnet_1.6',
@@ -60,7 +60,7 @@ export default class UnInstallCommand extends BaseCommand {
 
 		const tasks = new Listr([
 			{
-				title: `UnInstall Lisk Core ${network} Installed as ${name}`,
+				title: `UnInstall Lisk ${network} Installed as ${name}`,
 				task: () =>
 					new Listr([
 						{

--- a/src/commands/node/uninstall.ts
+++ b/src/commands/node/uninstall.ts
@@ -49,20 +49,11 @@ export default class UnInstallCommand extends BaseCommand {
 		const tasks = new Listr([
 			{
 				title: `UnInstall Lisk ${network} Installed as ${name}`,
-				task: () =>
-					new Listr([
-						{
-							title: 'Stop Services',
-							task: async () => StopCommand.run([name]),
-						},
-						{
-							title: 'Remove Process and Directory',
-							task: async () => {
-								await unRegisterApplication(name);
-								fsExtra.removeSync(installDir);
-							},
-						},
-					]),
+				task: async () => {
+					await StopCommand.run([name]);
+					await unRegisterApplication(name);
+					fsExtra.removeSync(installDir);
+				}
 			},
 		]);
 

--- a/src/commands/node/upgrade.ts
+++ b/src/commands/node/upgrade.ts
@@ -19,7 +19,7 @@ import * as fsExtra from 'fs-extra';
 import Listr from 'listr';
 import semver from 'semver';
 import BaseCommand from '../../base';
-import { NETWORK, RELEASE_URL } from '../../utils/constants';
+import { RELEASE_URL } from '../../utils/constants';
 import { downloadLiskAndValidate, extract } from '../../utils/download';
 import { flags as commonFlags } from '../../utils/flags';
 import {
@@ -40,6 +40,9 @@ import StopCommand from './stop';
 
 interface Flags {
 	readonly 'lisk-version': string;
+}
+
+interface Args {
 	readonly name: string;
 }
 
@@ -78,29 +81,31 @@ const validateVersion = async (
 };
 
 export default class UpgradeCommand extends BaseCommand {
+	static args = [
+		{
+			name: 'name',
+			description: 'Lisk installation directory name.',
+			required: true,
+		},
+	];
+
 	static description = 'Upgrade locally installed Lisk instance to specified or latest version';
 
 	static examples = [
-		'node:upgrade --name=mainnet_1.6',
-		'node:upgrade --name=mainnet_1.6 --version=1.7.1',
-		'node:upgrade --network=testnet --name=testnet_1.6',
-		'node:upgrade --network=testnet --name=testnet_1.6 --version=1.6.1',
+		'node:upgrade --lisk-version=2.0.0 mainnet_1.6',
 	];
 
 	static flags = {
 		...BaseCommand.flags,
-		name: flagParser.string({
-			...commonFlags.name,
-			default: NETWORK.MAINNET,
-		}),
 		'lisk-version': flagParser.string({
 			...commonFlags.version,
 		}),
 	};
 
 	async run(): Promise<void> {
-		const { flags } = this.parse(UpgradeCommand);
-		const { name, 'lisk-version': liskVersion } = flags as Flags;
+		const { args, flags } = this.parse(UpgradeCommand);
+		const { name }: Args = args;
+		const { 'lisk-version': liskVersion } = flags as Flags;
 		const { pm2_env } = await describeApplication(name);
 		const { pm_cwd: installDir, LISK_NETWORK: network } = pm2_env as Pm2Env;
 		const { version: currentVersion } = getConfig(

--- a/src/commands/node/upgrade.ts
+++ b/src/commands/node/upgrade.ts
@@ -78,7 +78,7 @@ const validateVersion = async (
 };
 
 export default class UpgradeCommand extends BaseCommand {
-	static description = 'Upgrade locally installed Lisk Core instance to specified or latest version';
+	static description = 'Upgrade locally installed Lisk instance to specified or latest version';
 
 	static examples = [
 		'node:upgrade --name=mainnet_1.6',
@@ -120,35 +120,35 @@ export default class UpgradeCommand extends BaseCommand {
 					validateVersion(network, currentVersion, upgradeVersion),
 			},
 			{
-				title: 'Stop and Unregister Lisk Services',
+				title: 'Stop and Unregister Lisk',
 				task: () =>
 					new Listr([
 						{
-							title: 'Stop Lisk Services',
+							title: 'Stop Lisk',
 							task: async () =>
 								StopCommand.run(['--network', network, '--name', name]),
 						},
 						{
-							title: `Unregister Lisk Core: ${name} from PM2`,
+							title: `Unregister Lisk: ${name} from PM2`,
 							task: async () => unRegisterApplication(name),
 						},
 					]),
 			},
 			{
-				title: 'Download, Backup and Install Lisk Core',
+				title: 'Download, Backup and Install Lisk',
 				task: () =>
 					new Listr([
 						{
-							title: `Download Lisk Core: ${upgradeVersion} Release`,
+							title: `Download Lisk: ${upgradeVersion} Release`,
 							task: async () =>
 								downloadLiskAndValidate(cacheDir, releaseUrl, upgradeVersion),
 						},
 						{
-							title: `Backup Lisk Core: ${currentVersion} installed as ${name}`,
+							title: `Backup Lisk: ${currentVersion} installed as ${name}`,
 							task: async () => backupLisk(installDir),
 						},
 						{
-							title: `Install Lisk Core: ${upgradeVersion}`,
+							title: `Install Lisk: ${upgradeVersion}`,
 							task: async () => {
 								fsExtra.ensureDirSync(installDir);
 								await extract(cacheDir, liskTar(upgradeVersion), installDir);
@@ -157,12 +157,12 @@ export default class UpgradeCommand extends BaseCommand {
 					]),
 			},
 			{
-				title: `Upgrade Lisk Core from: ${currentVersion} to: ${upgradeVersion}`,
+				title: `Upgrade Lisk from: ${currentVersion} to: ${upgradeVersion}`,
 				task: async () =>
 					upgradeLisk(installDir, name, network, currentVersion),
 			},
 			{
-				title: `Start Lisk Core: ${upgradeVersion}`,
+				title: `Start Lisk: ${upgradeVersion}`,
 				task: async () => {
 					await registerApplication(installDir, network, name);
 					await StartCommand.run(['--network', network, '--name', name]);

--- a/src/commands/node/upgrade.ts
+++ b/src/commands/node/upgrade.ts
@@ -91,9 +91,7 @@ export default class UpgradeCommand extends BaseCommand {
 
 	static description = 'Upgrade locally installed Lisk instance to specified or latest version';
 
-	static examples = [
-		'node:upgrade --lisk-version=2.0.0 mainnet_1.6',
-	];
+	static examples = ['node:upgrade --lisk-version=2.0.0 mainnet_1.6'];
 
 	static flags = {
 		...BaseCommand.flags,
@@ -112,15 +110,15 @@ export default class UpgradeCommand extends BaseCommand {
 			`${installDir}/package.json`,
 		) as PackageJson;
 		const upgradeVersion: string = await getVersionToUpgrade(
-			liskVersion,
 			network,
+			liskVersion,
 		);
 		const releaseUrl = `${RELEASE_URL}/${network}/${upgradeVersion}`;
 		const { cacheDir } = this.config;
 
 		const tasks = new Listr([
 			{
-				title: 'Validate Version',
+				title: 'Validate Version Input',
 				task: async () =>
 					validateVersion(network, currentVersion, upgradeVersion),
 			},
@@ -130,8 +128,7 @@ export default class UpgradeCommand extends BaseCommand {
 					new Listr([
 						{
 							title: 'Stop Lisk',
-							task: async () =>
-								StopCommand.run(['--network', network, '--name', name]),
+							task: async () => StopCommand.run([name]),
 						},
 						{
 							title: `Unregister Lisk: ${name} from PM2`,
@@ -170,7 +167,7 @@ export default class UpgradeCommand extends BaseCommand {
 				title: `Start Lisk: ${upgradeVersion}`,
 				task: async () => {
 					await registerApplication(installDir, network, name);
-					await StartCommand.run(['--network', network, '--name', name]);
+					await StartCommand.run([name]);
 				},
 			},
 		]);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -67,6 +67,18 @@ export enum NETWORK {
 	BETANET = 'betanet',
 }
 
+export const POSTGRES_PORTS = {
+	mainnet: 5432,
+	testnet: 5433,
+	betanet: 5434,
+};
+
+export const REDIS_PORTS = {
+	mainnet: 6380,
+	testnet: 6381,
+	betanet: 6382,
+};
+
 export enum OS {
 	Darwin = 'MACOS',
 	Linux = 'LINUX',

--- a/src/utils/flags.ts
+++ b/src/utils/flags.ts
@@ -68,8 +68,7 @@ const noSignatureDescription =
 
 const networkDescription = 'Name of the network to install.';
 const installationPathDescription = 'Path of Lisk to install.';
-const releaseUrlDescription =
-	'URL of the repository to download the Lisk.';
+const releaseUrlDescription = 'URL of the repository to download the Lisk.';
 const snapshotUrlDescription = 'URL of the Lisk blockchain snapshot.';
 const noSnapshotDescription = 'Install Lisk without blockchain snapshot';
 const liskVersionDescription =

--- a/src/utils/flags.ts
+++ b/src/utils/flags.ts
@@ -67,14 +67,13 @@ const noSignatureDescription =
 	'Creates the transaction without a signature. Your passphrase will therefore not be required.';
 
 const networkDescription = 'Name of the network to install.';
-const installationPathDescription = 'Path of Lisk Core to install.';
-const nameDescription = 'Lisk Core installation directory name.';
+const installationPathDescription = 'Path of Lisk to install.';
 const releaseUrlDescription =
-	'URL of the repository to download the Lisk Core.';
-const snapshotUrlDescription = 'URL of the Lisk Core blockchain snapshot.';
-const noSnapshotDescription = 'Install Lisk Core without blockchain snapshot';
+	'URL of the repository to download the Lisk.';
+const snapshotUrlDescription = 'URL of the Lisk blockchain snapshot.';
+const noSnapshotDescription = 'Install Lisk without blockchain snapshot';
 const liskVersionDescription =
-	'Upgrade locally installed Lisk Core instance to specified version';
+	'Upgrade locally installed Lisk instance to specified version';
 
 export type AlphabetLowercase =
 	| 'a'
@@ -144,9 +143,6 @@ export const flags: FlagMap = {
 	installationPath: {
 		char: 'p',
 		description: installationPathDescription,
-	},
-	name: {
-		description: nameDescription,
 	},
 	releaseUrl: {
 		char: 'r',

--- a/src/utils/node/cache.ts
+++ b/src/utils/node/cache.ts
@@ -48,7 +48,7 @@ export const startCache = async (
 ): Promise<string> => {
 	const redisPort: number = REDIS_PORTS[network];
 	const { stdout, stderr }: ExecResult = await exec(
-		`cd ${installDir}; ${REDIS_BIN} ${REDIS_CONFIG} -p ${redisPort}`,
+		`cd ${installDir}; ${REDIS_BIN} ${REDIS_CONFIG} --port ${redisPort}`,
 	);
 
 	if (stdout.trim() === '') {

--- a/src/utils/node/cache.ts
+++ b/src/utils/node/cache.ts
@@ -13,6 +13,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import { NETWORK, REDIS_PORTS } from '../constants';
 import { exec, ExecResult } from '../worker-process';
 import { CacheConfig, getCacheConfig } from './config';
 
@@ -27,12 +28,12 @@ const REDIS_CLI = 'bin/redis-cli';
 
 export const isCacheRunning = async (
 	installDir: string,
-	network: string,
+	network: NETWORK,
 ): Promise<boolean> => {
 	try {
-		const { port }: CacheConfig = getCacheConfig(installDir, network);
+		const redisPort: number = REDIS_PORTS[network];
 		const { stdout }: ExecResult = await exec(
-			`cd ${installDir}; ${REDIS_CLI} -p ${port} ping`,
+			`cd ${installDir}; ${REDIS_CLI} -p ${redisPort} ping`,
 		);
 
 		return stdout.search('PONG') >= 0;
@@ -41,9 +42,13 @@ export const isCacheRunning = async (
 	}
 };
 
-export const startCache = async (installDir: string): Promise<string> => {
+export const startCache = async (
+	installDir: string,
+	network: NETWORK,
+): Promise<string> => {
+	const redisPort: number = REDIS_PORTS[network];
 	const { stdout, stderr }: ExecResult = await exec(
-		`cd ${installDir}; ${REDIS_BIN} ${REDIS_CONFIG}`,
+		`cd ${installDir}; ${REDIS_BIN} ${REDIS_CONFIG} -p ${redisPort}`,
 	);
 
 	if (stdout.trim() === '') {
@@ -53,19 +58,20 @@ export const startCache = async (installDir: string): Promise<string> => {
 	throw new Error(`${CACHE_START_FAILURE}: \n\n ${stderr}`);
 };
 
-const stopCommand = (installDir: string, network: string): string => {
-	const { port, password }: CacheConfig = getCacheConfig(installDir, network);
+const stopCommand = (installDir: string, network: NETWORK): string => {
+	const { password }: CacheConfig = getCacheConfig(installDir, network);
+	const redisPort: number = REDIS_PORTS[network];
 
 	if (password) {
-		return `${REDIS_CLI} -p ${port} -a ${password} shutdown`;
+		return `${REDIS_CLI} -p ${redisPort} -a ${password} shutdown`;
 	}
 
-	return `${REDIS_CLI} -p ${port} shutdown`;
+	return `${REDIS_CLI} -p ${redisPort} shutdown`;
 };
 
 export const stopCache = async (
 	installDir: string,
-	network: string,
+	network: NETWORK,
 ): Promise<string> => {
 	const { stdout, stderr }: ExecResult = await exec(
 		`cd ${installDir}; ${stopCommand(installDir, network)}`,

--- a/src/utils/node/commons.ts
+++ b/src/utils/node/commons.ts
@@ -133,6 +133,8 @@ export const upgradeLisk = async (
 	if (stderr) {
 		throw new Error(stderr);
 	}
+
+	fsExtra.emptyDirSync(defaultBackupPath);
 };
 
 export const validateVersion = async (

--- a/src/utils/node/pm2.ts
+++ b/src/utils/node/pm2.ts
@@ -10,6 +10,7 @@ import {
 	start,
 	stop,
 } from 'pm2';
+import { NETWORK, POSTGRES_PORTS, REDIS_PORTS } from '../constants';
 
 export type ProcessStatus =
 	| 'online'
@@ -20,7 +21,9 @@ export type ProcessStatus =
 	| 'one-launch-status';
 
 export interface Pm2Env {
-	readonly LISK_NETWORK: string;
+	readonly LISK_DB_PORT: string;
+	readonly LISK_NETWORK: NETWORK;
+	readonly LISK_REDIS_PORT: string;
 	readonly pm_cwd: string;
 	readonly pm_uptime: number;
 	readonly status: ProcessStatus;
@@ -42,10 +45,13 @@ const connectPM2 = async (): Promise<void> =>
 
 const startPM2 = async (
 	installPath: string,
-	network: string,
+	network: NETWORK,
 	name: string,
-): Promise<void> =>
-	new Promise<void>((resolve, reject) => {
+): Promise<void> => {
+	const dbPort = POSTGRES_PORTS[network].toString();
+	const redisPort = REDIS_PORTS[network].toString();
+
+	return new Promise<void>((resolve, reject) => {
 		start(
 			{
 				name,
@@ -53,6 +59,8 @@ const startPM2 = async (
 				cwd: installPath,
 				env: {
 					LISK_NETWORK: network,
+					LISK_DB_PORT: dbPort,
+					LISK_REDIS_PORT: redisPort,
 				},
 				pid: path.join(installPath, '/pids/lisk.app.pid'),
 				output: path.join(installPath, '/logs/lisk.app.log'),
@@ -76,6 +84,7 @@ const startPM2 = async (
 			},
 		);
 	});
+};
 
 const restartPM2 = async (process: string | number): Promise<void> =>
 	new Promise<void>((resolve, reject) => {
@@ -149,7 +158,7 @@ const deleteProcess = async (process: string | number): Promise<void> =>
 
 export const registerApplication = async (
 	installPath: string,
-	network: string,
+	network: NETWORK,
 	name: string,
 ): Promise<void> => {
 	await connectPM2();

--- a/src/utils/node/pm2.ts
+++ b/src/utils/node/pm2.ts
@@ -25,6 +25,7 @@ export interface Pm2Env {
 	readonly pm_uptime: number;
 	readonly status: ProcessStatus;
 	readonly unstable_restarts: number;
+	readonly version: string;
 }
 
 const connectPM2 = async (): Promise<void> =>


### PR DESCRIPTION
### What was the problem?

- Show all the info for status, but status should show
- Name, installationPath, LISK_NETWORK, version, uptime, restart time, memory and CPU
- Not use the name Lisk Core referring to the application
- Update name to be the argument
- For db and redis, we will use constants for now

### How did I fix it?
Implemented the changes
### How to test it?
run all lisk node commands `lisk node --help`
### Review checklist

* The PR resolves #700 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
